### PR TITLE
mt7921: guard TXRX_NOTIFY against non-mmio buses

### DIFF
--- a/mt7921/mac.c
+++ b/mt7921/mac.c
@@ -568,7 +568,14 @@ bool mt7921_rx_check(struct mt76_dev *mdev, void *data, int len)
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
-		/* PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices */
+		/* PKT_TYPE_TXRX_NOTIFY is an mmio-only path. On USB/SDIO the
+		 * tx queue ops may be mid-teardown; calling through them can
+		 * land on a NULL function pointer. Drop silently.
+		 */
+		if (mt76_is_usb(mdev) || mt76_is_sdio(mdev)) {
+			dev_warn_once(mdev->dev, "spurious TXRX_NOTIFY on non-mmio bus\n");
+			return false;
+		}
 		mt7921_mac_tx_free(dev, data, len); /* mmio */
 		return false;
 	case PKT_TYPE_TXS:
@@ -598,7 +605,15 @@ void mt7921_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
-		/* PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices */
+		/* PKT_TYPE_TXRX_NOTIFY is an mmio-only path. On USB/SDIO the
+		 * tx queue ops may be mid-teardown; calling through them can
+		 * land on a NULL function pointer. Drop silently.
+		 */
+		if (mt76_is_usb(mdev) || mt76_is_sdio(mdev)) {
+			dev_warn_once(mdev->dev, "spurious TXRX_NOTIFY on non-mmio bus\n");
+			napi_consume_skb(skb, 1);
+			break;
+		}
 		mt7921_mac_tx_free(dev, skb->data, skb->len);
 		napi_consume_skb(skb, 1);
 		break;


### PR DESCRIPTION
A code comment at `mt7921/mac.c:571` and `mt7921/mac.c:601` says "PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices." Nothing in the switch enforces that invariant. If the firmware emits a TXRX_NOTIFY frame on USB, `mt7921_mac_tx_free()` gets called, which dispatches through the tx queue ops table. Those callbacks are USB-path ops, not the PCIe ops the function assumes, and during a partial teardown (for example, an in-flight RX burst the same instant mon0 enters promiscuous mode) one of them is NULL. Jumping through NULL = RIP=0 oops at `mt7921_mac_tx_free+0x5a`.

I hit this on my Framework laptop yesterday (2026-04-17) during active-monitor testing against an MT7921U USB adapter (0e8d:7961) with mdk4 beacon flood. Kernel 6.19.12-200.fc43, the `_git` tree of this repo at HEAD `1317710`. Call trace:

    mt7921_mac_tx_free+0x5a/0x270 [mt7921_common]
    mt7921_queue_rx_skb+0xef/0x120 [mt7921_common]
    mt76u_process_rx_entry+0x2d9/0x320 [mt76_usb]
    mt76u_rx_worker+0xf8/0x290 [mt76_usb]
    __mt76_worker_fn+0x53/0xa0 [mt76]

The fix uses the existing `mt76_is_usb()` / `mt76_is_sdio()` helpers to turn the code comment into an actual runtime check. Spurious non-mmio TXRX_NOTIFY frames are logged once per boot via `dev_warn_once()` and dropped. The same oops-susceptible code exists verbatim in upstream mt76, so a parallel submission to linux-wireless is planned after 7.1-rc1 lands.

I validated the fix deterministically by building a module-param fault-injection tree that forces the TXRX_NOTIFY classification on every 10th USB RX. Unpatched + inject reproduces the exact crash stack above. Patched + same inject produces:

    mt7921u 2-1:1.3: FAULT-INJECT: forcing TXRX_NOTIFY
    mt7921u 2-1:1.3: spurious TXRX_NOTIFY on non-mmio bus

No BUG, no Oops, no NULL deref. Cross-distro sanity: Ubuntu 24.04 (6.17), Fedora 42 (6.19), Kali rolling (6.18) and Alpine 3.23 (6.18 LTS) all build clean against this patch, 44 stress rounds total with zero regressions.

@morrownr tagging you for awareness.