### PR TITLE
info: correct mt7921 / mt7922 mainline kernel entries and Debian 12 cell

### DIFF
--- a/info/MARKET-FOOTPRINT.md
+++ b/info/MARKET-FOOTPRINT.md
@@ -82,8 +82,8 @@ Confirmed non-MediaTek: Lenovo ThinkStation P3 Tower/Tiny/Ultra + P5 + P7 + P8 (
 
 | Chip | Mainline kernel | Ubuntu 24.04 LTS (6.8/6.14 HWE) | Debian 13 trixie (6.12) | Debian 12 (6.1) | Fedora 42 (6.14) | Fedora 43 (6.17) | RHEL 10.1 (6.12) | RHEL 9 (5.14) | openSUSE Leap 16 (6.12) |
 |------|-----------------|-------------------------------|----------------------|-----------------|------------------|------------------|------------------|----------------|-------------------------|
-| MT7921 | 5.18 | yes | yes | yes (via backport) | yes | yes | yes | backport only | yes |
-| MT7922 | 5.17 | yes | yes | yes | yes | yes | yes | backport only | yes |
+| MT7921 | 5.12 | yes | yes | yes | yes | yes | yes | backport only | yes |
+| MT7922 | 5.16 | yes | yes | yes | yes | yes | yes | backport only | yes |
 | MT7925 | 6.7 | HWE only | yes | no | yes | yes | yes | no | yes |
 | MT7920 | 6.10 | HWE only | yes | no | yes | yes | yes | no | yes |
 | MT7902 | in mainline master via nbd tree 2026-03-24; v7.1 release track | not yet (6.14 HWE) | not yet | no | not yet | yes (6.17 reached) | not yet | no | not yet |


### PR DESCRIPTION
Two table errors in `info/MARKET-FOOTPRINT.md` caught in review of #8:

1. **MT7921 "Mainline kernel" cell** read `5.18`. That matches when the USB variant (mt7921u) landed; mt7921e (PCIe, by far the dominant deployment in the probe counts) first landed in **5.12** via commit `5c14a5f944`, mt7921s (SDIO) in **5.16** via `48fab5bbef`. Changed to 5.12 to reflect the earliest and most-deployed variant.
2. **MT7921 Debian 12 cell** read `yes (via backport)`. Debian 12 ships kernel 6.1, which contains all three MT7921 variants natively (5.12 / 5.16 / 5.18 all < 6.1). No backport required. Changed to `yes`.
3. **MT7922 "Mainline kernel" cell** read `5.17`. Actual intro commit `688088728b` first lands in **5.16** (diverged at v5.15, behind at v5.16 per `gh api compare`). Changed to 5.16.

Verified each landing via `gh api repos/torvalds/linux/compare/<tag>...<sha>` against torvalds master.

Leaves the RHEL 9 (5.14) "backport only" cells untouched -- whether Red Hat actually ships mt7921e (in kernel 5.12 upstream, therefore in principle native to RHEL 9's 5.14 base) depends on their selective cherry-pick decisions, which I have not verified.