### PR TITLE
wifi: mt76: add kernel 6.13-6.17 compat for mac80211 ieee80211_ops API changes

### DIFF
--- a/mac80211.c
+++ b/mac80211.c
@@ -1778,8 +1778,14 @@ s8 mt76_get_power_bound(struct mt76_phy *phy, s8 txpower)
 }
 EXPORT_SYMBOL_GPL(mt76_get_power_bound);
 
+/* compat: get_txpower gained link_id in kernel 6.14 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		     unsigned int link_id, int *dbm)
+#else
+int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+		     int *dbm)
+#endif
 {
 	struct mt76_phy *phy = mt76_vif_phy(hw, vif);
 	int n_chains, delta;
@@ -1959,8 +1965,13 @@ void mt76_sw_scan_complete(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
 }
 EXPORT_SYMBOL_GPL(mt76_sw_scan_complete);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 int mt76_get_antenna(struct ieee80211_hw *hw, int radio_idx, u32 *tx_ant,
 		     u32 *rx_ant)
+#else
+int mt76_get_antenna(struct ieee80211_hw *hw, u32 *tx_ant, u32 *rx_ant)
+#endif
 {
 	struct mt76_phy *phy = hw->priv;
 	struct mt76_dev *dev = phy->dev;

--- a/mt76.h
+++ b/mt76.h
@@ -1599,8 +1599,14 @@ int mt76_get_min_avg_rssi(struct mt76_dev *dev, u8 phy_idx);
 
 s8 mt76_get_power_bound(struct mt76_phy *phy, s8 txpower);
 
+/* compat: get_txpower gained link_id in kernel 6.14 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		     unsigned int link_id, int *dbm);
+#else
+int mt76_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+		     int *dbm);
+#endif
 int mt76_init_sar_power(struct ieee80211_hw *hw,
 			const struct cfg80211_sar_specs *sar);
 int mt76_get_sar_power(struct mt76_phy *phy,
@@ -1610,8 +1616,13 @@ int mt76_get_sar_power(struct mt76_phy *phy,
 void mt76_csa_check(struct mt76_dev *dev);
 void mt76_csa_finish(struct mt76_dev *dev);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 int mt76_get_antenna(struct ieee80211_hw *hw, int radio_idx, u32 *tx_ant,
 		     u32 *rx_ant);
+#else
+int mt76_get_antenna(struct ieee80211_hw *hw, u32 *tx_ant, u32 *rx_ant);
+#endif
 int mt76_set_tim(struct ieee80211_hw *hw, struct ieee80211_sta *sta, bool set);
 void mt76_insert_ccmp_hdr(struct sk_buff *skb, u8 key_id);
 int mt76_get_rate(struct mt76_dev *dev,

--- a/mt7603/main.c
+++ b/mt7603/main.c
@@ -215,8 +215,14 @@ static int mt7603_set_sar_specs(struct ieee80211_hw *hw,
 	return mt76_update_channel(mphy);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7603_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int
+mt7603_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt7603_dev *dev = hw->priv;
 	int ret = 0;
@@ -656,9 +662,15 @@ mt7603_sta_rate_tbl_update(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	spin_unlock_bh(&dev->mt76.lock);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static void
 mt7603_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 			  s16 coverage_class)
+#else
+static void
+mt7603_set_coverage_class(struct ieee80211_hw *hw, s16 coverage_class)
+#endif
 {
 	struct mt7603_dev *dev = hw->priv;
 

--- a/mt7615/main.c
+++ b/mt7615/main.c
@@ -426,7 +426,12 @@ static int mt7615_set_sar_specs(struct ieee80211_hw *hw,
 	return mt76_update_channel(phy->mt76);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7615_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int mt7615_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt7615_dev *dev = mt7615_hw_dev(hw);
 	struct mt7615_phy *phy = mt7615_hw_phy(hw);
@@ -791,8 +796,13 @@ static void mt7615_tx(struct ieee80211_hw *hw,
 	mt76_connac_pm_queue_skb(hw, &dev->pm, wcid, skb);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7615_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx,
 				    u32 val)
+#else
+static int mt7615_set_rts_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	struct mt7615_dev *dev = mt7615_hw_dev(hw);
 	struct mt7615_phy *phy = mt7615_hw_phy(hw);
@@ -979,9 +989,15 @@ mt7615_offset_tsf(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	mt7615_mutex_release(dev);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static void
 mt7615_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 			  s16 coverage_class)
+#else
+static void
+mt7615_set_coverage_class(struct ieee80211_hw *hw, s16 coverage_class)
+#endif
 {
 	struct mt7615_phy *phy = mt7615_hw_phy(hw);
 	struct mt7615_dev *dev = phy->dev;
@@ -992,9 +1008,15 @@ mt7615_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 	mt7615_mutex_release(dev);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7615_set_antenna(struct ieee80211_hw *hw, int radio_idx,
 		   u32 tx_ant, u32 rx_ant)
+#else
+static int
+mt7615_set_antenna(struct ieee80211_hw *hw, u32 tx_ant, u32 rx_ant)
+#endif
 {
 	struct mt7615_dev *dev = mt7615_hw_dev(hw);
 	struct mt7615_phy *phy = mt7615_hw_phy(hw);

--- a/mt76x0/main.c
+++ b/mt76x0/main.c
@@ -57,7 +57,12 @@ out:
 }
 EXPORT_SYMBOL_GPL(mt76x0_set_sar_specs);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 int mt76x0_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+int mt76x0_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt76x02_dev *dev = hw->priv;
 

--- a/mt76x0/mt76x0.h
+++ b/mt76x0/mt76x0.h
@@ -48,7 +48,12 @@ void mt76x0_chip_onoff(struct mt76x02_dev *dev, bool enable, bool reset);
 
 void mt76x0_mac_stop(struct mt76x02_dev *dev);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 int mt76x0_config(struct ieee80211_hw *hw, int radio_idx, u32 changed);
+#else
+int mt76x0_config(struct ieee80211_hw *hw, u32 changed);
+#endif
 int mt76x0_set_channel(struct mt76_phy *mphy);
 int mt76x0_set_sar_specs(struct ieee80211_hw *hw,
 			 const struct cfg80211_sar_specs *sar);

--- a/mt76x02.h
+++ b/mt76x02.h
@@ -182,9 +182,16 @@ s8 mt76x02_tx_get_txpwr_adj(struct mt76x02_dev *dev, s8 txpwr,
 void mt76x02_wdt_work(struct work_struct *work);
 void mt76x02_tx_set_txpwr_auto(struct mt76x02_dev *dev, s8 txpwr);
 void mt76x02_set_tx_ackto(struct mt76x02_dev *dev);
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 void mt76x02_set_coverage_class(struct ieee80211_hw *hw,
 				int radio_idx, s16 coverage_class);
 int mt76x02_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx, u32 val);
+#else
+void mt76x02_set_coverage_class(struct ieee80211_hw *hw,
+				s16 coverage_class);
+int mt76x02_set_rts_threshold(struct ieee80211_hw *hw, u32 val);
+#endif
 void mt76x02_remove_hdr_pad(struct sk_buff *skb, int len);
 bool mt76x02_tx_status_data(struct mt76_dev *mdev, u8 *update);
 void mt76x02_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,

--- a/mt76x02_util.c
+++ b/mt76x02_util.c
@@ -547,8 +547,14 @@ void mt76x02_set_tx_ackto(struct mt76x02_dev *dev)
 }
 EXPORT_SYMBOL_GPL(mt76x02_set_tx_ackto);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 void mt76x02_set_coverage_class(struct ieee80211_hw *hw,
 				int radio_idx, s16 coverage_class)
+#else
+void mt76x02_set_coverage_class(struct ieee80211_hw *hw,
+				s16 coverage_class)
+#endif
 {
 	struct mt76x02_dev *dev = hw->priv;
 
@@ -559,7 +565,12 @@ void mt76x02_set_coverage_class(struct ieee80211_hw *hw,
 }
 EXPORT_SYMBOL_GPL(mt76x02_set_coverage_class);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 int mt76x02_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx, u32 val)
+#else
+int mt76x02_set_rts_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	struct mt76x02_dev *dev = hw->priv;
 

--- a/mt76x2/pci_main.c
+++ b/mt76x2/pci_main.c
@@ -53,8 +53,14 @@ int mt76x2e_set_channel(struct mt76_phy *phy)
 	return 0;
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt76x2_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int
+mt76x2_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt76x02_dev *dev = hw->priv;
 
@@ -99,8 +105,14 @@ mt76x2_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 {
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt76x2_set_antenna(struct ieee80211_hw *hw, int radio_idx,
 			      u32 tx_ant, u32 rx_ant)
+#else
+static int mt76x2_set_antenna(struct ieee80211_hw *hw,
+			      u32 tx_ant, u32 rx_ant)
+#endif
 {
 	struct mt76x02_dev *dev = hw->priv;
 

--- a/mt76x2/usb_main.c
+++ b/mt76x2/usb_main.c
@@ -49,8 +49,14 @@ int mt76x2u_set_channel(struct mt76_phy *mphy)
 	return err;
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt76x2u_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int
+mt76x2u_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt76x02_dev *dev = hw->priv;
 	int err = 0;

--- a/mt7915/main.c
+++ b/mt7915/main.c
@@ -449,8 +449,13 @@ out:
 	return err;
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7915_config(struct ieee80211_hw *hw, int radio_idx,
 			 u32 changed)
+#else
+static int mt7915_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt7915_dev *dev = mt7915_hw_dev(hw);
 	struct mt7915_phy *phy = mt7915_hw_phy(hw);
@@ -917,8 +922,13 @@ static void mt7915_tx(struct ieee80211_hw *hw,
 	mt76_tx(mphy, control->sta, wcid, skb);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7915_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx,
 				    u32 val)
+#else
+static int mt7915_set_rts_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	struct mt7915_dev *dev = mt7915_hw_dev(hw);
 	struct mt7915_phy *phy = mt7915_hw_phy(hw);
@@ -1113,9 +1123,15 @@ mt7915_offset_tsf(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	mutex_unlock(&dev->mt76.mutex);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static void
 mt7915_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 			  s16 coverage_class)
+#else
+static void
+mt7915_set_coverage_class(struct ieee80211_hw *hw, s16 coverage_class)
+#endif
 {
 	struct mt7915_phy *phy = mt7915_hw_phy(hw);
 	struct mt7915_dev *dev = phy->dev;
@@ -1126,8 +1142,14 @@ mt7915_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 	mutex_unlock(&dev->mt76.mutex);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7915_set_antenna(struct ieee80211_hw *hw, int radio_idx, u32 tx_ant, u32 rx_ant)
+#else
+static int
+mt7915_set_antenna(struct ieee80211_hw *hw, u32 tx_ant, u32 rx_ant)
+#endif
 {
 	struct mt7915_dev *dev = mt7915_hw_dev(hw);
 	struct mt7915_phy *phy = mt7915_hw_phy(hw);
@@ -1235,12 +1257,21 @@ static void mt7915_sta_rc_work(void *data, struct ieee80211_sta *sta)
 	spin_unlock_bh(&dev->mt76.sta_poll_lock);
 }
 
+/* compat: sta_rc_update renamed to link_sta_rc_update with link_sta arg in kernel 6.13 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 static void mt7915_sta_rc_update(struct ieee80211_hw *hw,
 				 struct ieee80211_vif *vif,
 				 struct ieee80211_link_sta *link_sta,
 				 u32 changed)
 {
 	struct ieee80211_sta *sta = link_sta->sta;
+#else
+static void mt7915_sta_rc_update(struct ieee80211_hw *hw,
+				 struct ieee80211_vif *vif,
+				 struct ieee80211_sta *sta,
+				 u32 changed)
+{
+#endif
 	struct mt7915_phy *phy = mt7915_hw_phy(hw);
 	struct mt7915_dev *dev = phy->dev;
 	struct mt7915_sta *msta = (struct mt7915_sta *)sta->drv_priv;
@@ -1704,8 +1735,14 @@ mt7915_twt_teardown_request(struct ieee80211_hw *hw,
 	mutex_unlock(&dev->mt76.mutex);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7915_set_frag_threshold(struct ieee80211_hw *hw, int radio_idx, u32 val)
+#else
+static int
+mt7915_set_frag_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	return 0;
 }
@@ -1825,7 +1862,12 @@ const struct ieee80211_ops mt7915_ops = {
 	.stop_ap = mt7915_stop_ap,
 	.sta_state = mt76_sta_state,
 	.sta_pre_rcu_remove = mt76_sta_pre_rcu_remove,
+	/* compat: sta_rc_update renamed to link_sta_rc_update in kernel 6.13 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 	.link_sta_rc_update = mt7915_sta_rc_update,
+#else
+	.sta_rc_update = mt7915_sta_rc_update,
+#endif
 	.set_key = mt7915_set_key,
 	.ampdu_action = mt7915_ampdu_action,
 	.set_rts_threshold = mt7915_set_rts_threshold,

--- a/mt7921/main.c
+++ b/mt7921/main.c
@@ -630,7 +630,12 @@ void mt7921_set_runtime_pm(struct mt792x_dev *dev)
 	mt76_connac_mcu_set_deep_sleep(&dev->mt76, pm->ds_enable);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7921_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int mt7921_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 	struct mt792x_phy *phy = mt792x_hw_phy(hw);
@@ -920,8 +925,13 @@ void mt7921_mac_sta_remove(struct mt76_dev *mdev, struct ieee80211_vif *vif,
 }
 EXPORT_SYMBOL_GPL(mt7921_mac_sta_remove);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7921_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx,
 				    u32 val)
+#else
+static int mt7921_set_rts_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 
@@ -1101,9 +1111,15 @@ mt7921_stop_sched_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
 	return err;
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7921_set_antenna(struct ieee80211_hw *hw, int radio_idx,
 		   u32 tx_ant, u32 rx_ant)
+#else
+static int
+mt7921_set_antenna(struct ieee80211_hw *hw, u32 tx_ant, u32 rx_ant)
+#endif
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 	struct mt792x_phy *phy = mt792x_hw_phy(hw);

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -770,7 +770,12 @@ void mt7925_set_runtime_pm(struct mt792x_dev *dev)
 	mt7925_mcu_set_deep_sleep(dev, pm->ds_enable);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7925_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int mt7925_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 	int ret = 0;
@@ -1336,8 +1341,13 @@ void mt7925_mac_sta_remove(struct mt76_dev *mdev, struct ieee80211_vif *vif,
 }
 EXPORT_SYMBOL_GPL(mt7925_mac_sta_remove);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7925_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx,
 				    u32 val)
+#else
+static int mt7925_set_rts_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 
@@ -1563,9 +1573,15 @@ mt7925_stop_sched_scan(struct ieee80211_hw *hw, struct ieee80211_vif *vif)
 	return err;
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7925_set_antenna(struct ieee80211_hw *hw, int radio_idx,
 		   u32 tx_ant, u32 rx_ant)
+#else
+static int
+mt7925_set_antenna(struct ieee80211_hw *hw, u32 tx_ant, u32 rx_ant)
+#endif
 {
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
 	struct mt792x_phy *phy = mt792x_hw_phy(hw);

--- a/mt792x.h
+++ b/mt792x.h
@@ -416,8 +416,13 @@ void mt792x_sta_statistics(struct ieee80211_hw *hw,
 			   struct ieee80211_vif *vif,
 			   struct ieee80211_sta *sta,
 			   struct station_info *sinfo);
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 void mt792x_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 			       s16 coverage_class);
+#else
+void mt792x_set_coverage_class(struct ieee80211_hw *hw, s16 coverage_class);
+#endif
 void mt792x_dma_cleanup(struct mt792x_dev *dev);
 int mt792x_dma_enable(struct mt792x_dev *dev);
 int mt792x_wpdma_reset(struct mt792x_dev *dev, bool force);

--- a/mt792x_core.c
+++ b/mt792x_core.c
@@ -607,8 +607,13 @@ void mt792x_sta_statistics(struct ieee80211_hw *hw,
 }
 EXPORT_SYMBOL_GPL(mt792x_sta_statistics);
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 void mt792x_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 			       s16 coverage_class)
+#else
+void mt792x_set_coverage_class(struct ieee80211_hw *hw, s16 coverage_class)
+#endif
 {
 	struct mt792x_phy *phy = mt792x_hw_phy(hw);
 	struct mt792x_dev *dev = phy->dev;

--- a/mt7996/init.c
+++ b/mt7996/init.c
@@ -536,7 +536,10 @@ mt7996_init_wiphy(struct ieee80211_hw *hw, struct mtk_wed_device *wed)
 	ieee80211_hw_set(hw, HAS_RATE_CONTROL);
 	ieee80211_hw_set(hw, SUPPORTS_TX_ENCAP_OFFLOAD);
 	ieee80211_hw_set(hw, SUPPORTS_RX_DECAP_OFFLOAD);
+	/* compat: IEEE80211_HW_NO_VIRTUAL_MONITOR added to mac80211 in kernel 6.15 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
 	ieee80211_hw_set(hw, NO_VIRTUAL_MONITOR);
+#endif
 	ieee80211_hw_set(hw, SUPPORTS_MULTI_BSSID);
 	ieee80211_hw_set(hw, CHANCTX_STA_CSA);
 

--- a/mt7996/main.c
+++ b/mt7996/main.c
@@ -7,6 +7,13 @@
 #include "mcu.h"
 #include "mac.h"
 
+/* compat: struct wireless_dev gained radio_mask in kernel 6.13; pre-6.13 is single-radio */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
+#define MT76_WDEV_RADIO_MASK(wdev) ((wdev)->radio_mask)
+#else
+#define MT76_WDEV_RADIO_MASK(wdev) ((void)(wdev), BIT(0))
+#endif
+
 int mt7996_run(struct mt7996_phy *phy)
 {
 	struct mt7996_dev *dev = phy->dev;
@@ -557,7 +564,7 @@ static int mt7996_add_interface(struct ieee80211_hw *hw,
 	for (i = 0; i < MT7996_MAX_RADIOS; i++) {
 		struct mt7996_phy *phy = dev->radio_phy[i];
 
-		if (!phy || !(wdev->radio_mask & BIT(i)) ||
+		if (!phy || !(MT76_WDEV_RADIO_MASK(wdev) & BIT(i)) ||
 		    test_bit(MT76_STATE_RUNNING, &phy->mt76->state))
 			continue;
 
@@ -590,9 +597,9 @@ static void mt7996_remove_iter(void *data, u8 *mac, struct ieee80211_vif *vif)
 	struct wireless_dev *wdev = ieee80211_vif_to_wdev(vif);
 	struct mt7996_radio_data *rdata = data;
 
-	rdata->active_mask |= wdev->radio_mask;
+	rdata->active_mask |= MT76_WDEV_RADIO_MASK(wdev);
 	if (vif->type == NL80211_IFTYPE_MONITOR)
-		rdata->monitor_mask |= wdev->radio_mask;
+		rdata->monitor_mask |= MT76_WDEV_RADIO_MASK(wdev);
 }
 
 static void mt7996_remove_interface(struct ieee80211_hw *hw,
@@ -734,7 +741,12 @@ static int mt7996_set_key(struct ieee80211_hw *hw, enum set_key_cmd cmd,
 	return err;
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7996_config(struct ieee80211_hw *hw, int radio_idx, u32 changed)
+#else
+static int mt7996_config(struct ieee80211_hw *hw, u32 changed)
+#endif
 {
 	return 0;
 }
@@ -810,9 +822,16 @@ static void mt7996_configure_filter(struct ieee80211_hw *hw,
 	mutex_unlock(&dev->mt76.mutex);
 }
 
+/* compat: get_txpower gained link_id in kernel 6.14 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 static int
 mt7996_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		   unsigned int link_id, int *dbm)
+#else
+static int
+mt7996_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+		   int *dbm)
+#endif
 {
 	struct mt7996_vif *mvif = (struct mt7996_vif *)vif->drv_priv;
 	struct mt7996_phy *phy = mt7996_vif_link_phy(&mvif->deflink);
@@ -823,7 +842,7 @@ mt7996_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	if (!phy) {
 		wdev = ieee80211_vif_to_wdev(vif);
 		for (i = 0; i < hw->wiphy->n_radio; i++)
-			if (wdev->radio_mask & BIT(i))
+			if (MT76_WDEV_RADIO_MASK(wdev) & BIT(i))
 				phy = dev->radio_phy[i];
 
 		if (!phy)
@@ -1580,8 +1599,13 @@ unlock:
 	rcu_read_unlock();
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int mt7996_set_rts_threshold(struct ieee80211_hw *hw, int radio_idx,
 				    u32 val)
+#else
+static int mt7996_set_rts_threshold(struct ieee80211_hw *hw, u32 val)
+#endif
 {
 	struct mt7996_dev *dev = mt7996_hw_dev(hw);
 	int i, ret = 0;
@@ -1800,9 +1824,15 @@ unlock:
 	mutex_unlock(&dev->mt76.mutex);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static void
 mt7996_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 			  s16 coverage_class)
+#else
+static void
+mt7996_set_coverage_class(struct ieee80211_hw *hw, s16 coverage_class)
+#endif
 {
 	struct mt7996_dev *dev = mt7996_hw_dev(hw);
 	struct mt7996_phy *phy;
@@ -1815,9 +1845,15 @@ mt7996_set_coverage_class(struct ieee80211_hw *hw, int radio_idx,
 	mutex_unlock(&dev->mt76.mutex);
 }
 
+/* compat: radio_idx added to ieee80211_ops in kernel 6.17 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 17, 0)
 static int
 mt7996_set_antenna(struct ieee80211_hw *hw, int radio_idx,
 		   u32 tx_ant, u32 rx_ant)
+#else
+static int
+mt7996_set_antenna(struct ieee80211_hw *hw, u32 tx_ant, u32 rx_ant)
+#endif
 {
 	struct mt7996_dev *dev = mt7996_hw_dev(hw);
 	int i;
@@ -1931,18 +1967,29 @@ static void mt7996_link_rate_ctrl_update(void *data,
 	spin_unlock_bh(&dev->mt76.sta_poll_lock);
 }
 
+/* compat: sta_rc_update renamed to link_sta_rc_update with link_sta arg in kernel 6.13 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 static void mt7996_link_sta_rc_update(struct ieee80211_hw *hw,
 				      struct ieee80211_vif *vif,
 				      struct ieee80211_link_sta *link_sta,
 				      u32 changed)
 {
 	struct ieee80211_sta *sta = link_sta->sta;
+	u8 link_id = link_sta->link_id;
+#else
+static void mt7996_link_sta_rc_update(struct ieee80211_hw *hw,
+				      struct ieee80211_vif *vif,
+				      struct ieee80211_sta *sta,
+				      u32 changed)
+{
+	u8 link_id = 0;  /* pre-6.13 kernels have no MLO: single link */
+#endif
 	struct mt7996_sta *msta = (struct mt7996_sta *)sta->drv_priv;
 	struct mt7996_sta_link *msta_link;
 
 	rcu_read_lock();
 
-	msta_link = mt7996_sta_link(msta, link_sta->link_id);
+	msta_link = mt7996_sta_link(msta, link_id);
 	if (msta_link) {
 		struct mt7996_dev *dev = mt7996_hw_dev(hw);
 
@@ -2521,7 +2568,12 @@ const struct ieee80211_ops mt7996_ops = {
 	.link_info_changed = mt7996_link_info_changed,
 	.sta_state = mt7996_sta_state,
 	.sta_pre_rcu_remove = mt76_sta_pre_rcu_remove,
+	/* compat: sta_rc_update renamed to link_sta_rc_update in kernel 6.13 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 	.link_sta_rc_update = mt7996_link_sta_rc_update,
+#else
+	.sta_rc_update = mt7996_link_sta_rc_update,
+#endif
 	.set_key = mt7996_set_key,
 	.ampdu_action = mt7996_ampdu_action,
 	.set_rts_threshold = mt7996_set_rts_threshold,


### PR DESCRIPTION
Scope B of #4. Completes the 6.12-to-6.16 kernel backport by covering
every `ieee80211_ops` API break between v6.12 and v6.17 that Scope A
(`13177102`) did not.

- **6.13** -- `sta_rc_update` renamed to `link_sta_rc_update` (third
  arg type flips to `ieee80211_link_sta *`). `struct wireless_dev`
  also gained `radio_mask`; pre-6.13 is single-radio via a small
  compat macro.
- **6.14** -- `get_txpower` gained `unsigned int link_id`.
- **6.15** -- `IEEE80211_HW_NO_VIRTUAL_MONITOR` guarded at
  `mt7996/init.c:539`. Closes the commitment to @ohquait on #6.
- **6.17** -- `int radio_idx` added to six callbacks (config,
  set_frag_threshold, set_rts_threshold, set_coverage_class,
  set_antenna, get_antenna). 29 impl sites + 5 header prototypes
  guarded.

Pattern matches Scope A: inline `#if LINUX_VERSION_CODE` with
`compat: ...` tag comments so the full surface is greppable and can
be removed cleanly when the minimum supported kernel rises past
these cutoffs.

Tested: Pi5 6.12.47 aarch64, debian 6.12 / ubuntu 6.17 / kali 6.18 /
alpine 6.18 (musl+gcc15) / fedora 6.19 x86_64. All compile and
load/unload clean, taints OOT-only. Runtime smoke (mon0 + live frame
capture) on Pi5 (native USB) and a debian 6.12 VM (USB passthrough)
with an Alfa AWUS036AXML -- real over-the-air beacons captured,
3 rounds of mon0 cycle stress with no oops/WARN.