### PR TITLE
Hotfix #11: comment out mt7915/mt7996 in dkms.conf and mt76_git.conf

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -49,10 +49,12 @@ if [ -e "/lib/modules/${kernelver}/build/.config" ] && \
 	# mt7603e_git is not built by default -- see Makefile note
 	#_NAMES+=("mt7603e_git");       _LOCS+=("mt7603/")
 	_NAMES+=("mt7615e_git");       _LOCS+=("mt7615/")
-	_NAMES+=("mt7915e_git");       _LOCS+=("mt7915/")
+	# mt7915e_git is not built by default -- see Makefile note
+	#_NAMES+=("mt7915e_git");       _LOCS+=("mt7915/")
 	_NAMES+=("mt7921e_git");       _LOCS+=("mt7921/")
 	_NAMES+=("mt7925e_git");       _LOCS+=("mt7925/")
-	_NAMES+=("mt7996e_git");       _LOCS+=("mt7996/")
+	# mt7996e_git is not built by default -- see Makefile note
+	#_NAMES+=("mt7996e_git");       _LOCS+=("mt7996/")
 	_NAMES+=("mt76x0e_git");      _LOCS+=("mt76x0/")
 	_NAMES+=("mt76x2e_git");      _LOCS+=("mt76x2/")
 fi

--- a/mt76_git.conf
+++ b/mt76_git.conf
@@ -45,8 +45,9 @@ blacklist mt7663_usb_sdio_common
 blacklist mt7663u
 blacklist mt7663s
 
-# MT7915 (PCIe)
-blacklist mt7915e
+# MT7915 (PCIe) -- not built by this repo. The in-kernel mt7915e is left
+# unblacklisted so users with MT7915/MT7916 hardware keep their working driver.
+#blacklist mt7915e
 
 # MT7921 family
 blacklist mt7921_common
@@ -59,8 +60,9 @@ blacklist mt7925_common
 blacklist mt7925e
 blacklist mt7925u
 
-# MT7996 (PCIe)
-blacklist mt7996e
+# MT7996 (PCIe) -- not built by this repo. The in-kernel mt7996e is left
+# unblacklisted so users with MT7996 hardware keep their working driver.
+#blacklist mt7996e
 
 # MT76x0 family
 blacklist mt76x0_common


### PR DESCRIPTION
Hotfix for regression from #11. Two files not updated alongside the
Makefile obj-m trim:

- **dkms.conf** still listed `mt7915e_git` and `mt7996e_git` in the
  BUILT_MODULE arrays. DKMS expects every listed .ko; when make no
  longer produces `mt7915/mt7915e_git.ko`, DKMS fails the whole
  install ("Error! Build of mt7915/mt7915e_git.ko failed").

- **mt76_git.conf** still blacklisted `mt7915e` and `mt7996e`.
  Combined with the Makefile not building replacements, users of
  MT7915/MT7996 hardware were left with no driver at all (in-kernel
  blacklisted, our-driver not built).

Same fix as the existing mt7603e pattern in both files: commented
out with a note. Source trees stay intact; anyone who uncomments
the Makefile line can uncomment the matching entries here.

Reported by @morrownr on #4 during 6.12 testing.

Followup: main README.md "Supported Chipset Families" table still
lists MT7915/MT7996 as active -- separate PR to move them under
"Inactive Families" alongside MT7603.