### PR TITLE
mt7921: assert sniffer enable on chanctx change

### DIFF
--- a/mt7921/main.c
+++ b/mt7921/main.c
@@ -1424,10 +1424,12 @@ mt7921_change_chanctx(struct ieee80211_hw *hw,
 	vif = container_of((void *)mvif, struct ieee80211_vif, drv_priv);
 
 	mt792x_mutex_acquire(phy->dev);
-	if (vif->type == NL80211_IFTYPE_MONITOR)
+	if (vif->type == NL80211_IFTYPE_MONITOR) {
+		mt7921_mcu_set_sniffer(mvif->phy->dev, vif, true);
 		mt7921_mcu_config_sniffer(mvif, ctx);
-	else
+	} else {
 		mt76_connac_mcu_uni_set_chctx(mvif->phy->mt76, &mvif->bss_conf.mt76, ctx);
+	}
 	mt792x_mutex_release(phy->dev);
 }
 


### PR DESCRIPTION
Fix for the mt7921u 0-BEACON regression reported in morrownr/USB-WiFi#682 and discussed in #18.

mt7925's change_chanctx calls both mt792x_mcu_set_sniffer(true) and mt7925_mcu_config_sniffer for monitor VIFs. mt7921's only called mt7921_mcu_config_sniffer, so monitor mode silently dropped frames after the first channel hop. This mirrors the mt7925 pattern.

Validated on a bare-metal Arch 6.17.9 rig matching @ZerBea's reproduction conditions: 0 BEACONs to 2795 BEACONs over 25 seconds of `hcxdumptool --rcascan=active` on the Alfa AWUS036AXML, with no driver errors or resets in dmesg.

Per the prior approval at #18.