### PR TITLE
mt76: 7.1 mac80211 action API compat

### DIFF
--- a/mt76_connac_mac.c
+++ b/mt76_connac_mac.c
@@ -412,11 +412,23 @@ mt76_connac2_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
 	u8 fc_type, fc_stype;
 	u32 val;
 
+/* compat: in kernel 7.1 IEEE80211_MIN_ACTION_SIZE became a function-like
+ * macro, the inner u.action.u union was flattened, and action_code moved
+ * to the action level instead of being a per-action-struct field.
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	if (ieee80211_is_action(fc) &&
+	    skb->len >= IEEE80211_MIN_ACTION_SIZE(addba_req) &&
+	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+	    mgmt->u.action.action_code == WLAN_ACTION_ADDBA_REQ) {
+		u16 capab = le16_to_cpu(mgmt->u.action.addba_req.capab);
+#else
 	if (ieee80211_is_action(fc) &&
 	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 &&
 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ) {
 		u16 capab = le16_to_cpu(mgmt->u.action.u.addba_req.capab);
+#endif
 
 		txwi[5] |= cpu_to_le32(MT_TXD5_ADD_BA);
 		tid = (capab >> 2) & IEEE80211_QOS_CTL_TID_MASK;

--- a/mt7925/mac.c
+++ b/mt7925/mac.c
@@ -667,10 +667,18 @@ mt7925_mac_write_txwi_80211(struct mt76_dev *dev, __le32 *txwi,
 	u8 fc_type, fc_stype;
 	u32 val;
 
+/* compat: see note in mt76_connac_mac.c -- 7.1 mac80211 action API change */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	if (ieee80211_is_action(fc) &&
+	    skb->len >= IEEE80211_MIN_ACTION_SIZE(addba_req) &&
+	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+	    mgmt->u.action.action_code == WLAN_ACTION_ADDBA_REQ)
+#else
 	if (ieee80211_is_action(fc) &&
 	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 &&
 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ)
+#endif
 		tid = MT_TX_ADDBA;
 	else if (ieee80211_is_mgmt(hdr->frame_control))
 		tid = MT_TX_NORMAL;

--- a/mt7996/mac.c
+++ b/mt7996/mac.c
@@ -762,10 +762,18 @@ mt7996_mac_write_txwi_80211(struct mt7996_dev *dev, __le32 *txwi,
 	u8 fc_type, fc_stype;
 	u32 val;
 
+/* compat: see note in mt76_connac_mac.c -- 7.1 mac80211 action API change */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)
+	if (ieee80211_is_action(fc) &&
+	    skb->len >= IEEE80211_MIN_ACTION_SIZE(addba_req) &&
+	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
+	    mgmt->u.action.action_code == WLAN_ACTION_ADDBA_REQ) {
+#else
 	if (ieee80211_is_action(fc) &&
 	    skb->len >= IEEE80211_MIN_ACTION_SIZE + 1 &&
 	    mgmt->u.action.category == WLAN_CATEGORY_BACK &&
 	    mgmt->u.action.u.addba_req.action_code == WLAN_ACTION_ADDBA_REQ) {
+#endif
 		if (is_mt7990(&dev->mt76))
 			txwi[6] |= cpu_to_le32(FIELD_PREP(MT_TXD6_TID_ADDBA, tid));
 		else


### PR DESCRIPTION
Closes #21.

Kernel 7.1 changed three things in `struct ieee80211_mgmt` action handling: `IEEE80211_MIN_ACTION_SIZE` became a function-like macro, the inner `u.action.u` union was flattened, and `action_code` moved from per-action structs up to the action level alongside `category`.

Three files exercise the addba_req path that intersects all three: `mt76_connac_mac.c`, `mt7925/mac.c`, `mt7996/mac.c`. Each gets a `LINUX_VERSION_CODE >= KERNEL_VERSION(7, 1, 0)` guard, mirroring the Scope A/B pattern.

Build verified across 9 platforms 6.12 through 7.1-rc1 (Debian, Arch, Fedora, Alpine, Kali, Ubuntu cloud images plus K8 Plus rig, Framework laptop, and torvalds master). Runtime smoke clean on three rigs (x86_64 6.17.9, x86_64 6.19.13, aarch64 6.12.47). @satmandu confirmed working on Ubuntu 26.04 / 7.1.0-rc1 / DKMS install per #21.