### PR TITLE
check-driver.sh: add sysfs fallback for hardware detection

### DIFF
--- a/check-driver.sh
+++ b/check-driver.sh
@@ -192,6 +192,35 @@ if command -v lspci >/dev/null 2>&1; then
 	fi
 fi
 
+# sysfs fallback: scan for USB devices bound to any mt76-family driver.
+# Catches rebadged adapters (e.g. NetGear A9000, 0846:9072) where lsusb
+# shows the rebadger's vendor ID instead of MediaTek's 0e8d, and the
+# vendor-string regex above never sees "mediatek" or "mt76".
+if [ "${FOUND_HW}" -eq 0 ]; then
+	for drv_path in /sys/bus/usb/drivers/mt7*; do
+		[ -d "${drv_path}" ] || continue
+		drv_name=$(basename "${drv_path}")
+		for dev_link in "${drv_path}"/*; do
+			[ -L "${dev_link}" ] || continue
+			dev_base=$(basename "${dev_link}")
+			[ "${dev_base}" = "module" ] && continue
+			# idVendor/idProduct/manufacturer/product live on the USB
+			# device one level up from the interface binding, so read
+			# from "${dev_link}/../" not "${dev_link}/"
+			dev_vid=$(cat "${dev_link}/../idVendor" 2>/dev/null)
+			dev_pid=$(cat "${dev_link}/../idProduct" 2>/dev/null)
+			dev_mfg=$(cat "${dev_link}/../manufacturer" 2>/dev/null)
+			dev_prd=$(cat "${dev_link}/../product" 2>/dev/null)
+			if [ -n "${dev_vid}" ] && [ -n "${dev_pid}" ]; then
+				info "USB: ID ${dev_vid}:${dev_pid} ${dev_mfg} ${dev_prd} (driver: ${drv_name})"
+			else
+				info "USB: ${dev_base} (driver: ${drv_name})"
+			fi
+			FOUND_HW=1
+		done
+	done
+fi
+
 if [ "${FOUND_HW}" -eq 0 ]; then
 	warn "No MediaTek wireless hardware detected"
 	info "If your device is connected, it may not be powered on or recognized"


### PR DESCRIPTION
Closes #26.

The lsusb regex `mediatek|mt76|0e8d:` does not match the NetGear A9000
(0846:9072) reported in #26 even though it is bound to mt7925u_git, so
the script prints "No MediaTek wireless hardware detected" on a working
rig. Add a sysfs walk that runs only when both lsusb and lspci regexes
come up empty: scans /sys/bus/usb/drivers/mt7* and reads
idVendor/idProduct/manufacturer/product per bound device. Same fallback
as install-driver.sh 5a52df3a + 42376895, so the two scripts now agree
on what counts as detected hardware.

Tests:

- shellcheck 0.11.0 and `sh -n`: clean.
- Real-hardware repro on Fedora 43 / kernel 6.19.13 with an Alfa
  AWUS036AXML (0e8d:7961, MT7921AU) bound to in-kernel mt7921u. The
  Alfa is mt76-vendored so the lsusb regex normally catches it; to
  exercise the new code path the regex was temporarily neutered to
  simulate the rebadge condition described in #26 (lsusb line carries
  no mediatek/mt76/0e8d token). With the regex neutered:
  - Unpatched script: warns "No MediaTek wireless hardware detected"
    -- exact reproduction of #26's failure mode.
  - Patched script: new sysfs walk emits `USB: ID 0e8d:7961 MediaTek
    Inc. Wireless_Device (driver: mt7921u)`, FOUND_HW=1.
- Pi 5 (arm64, dash via /bin/sh) with mt7921u driver loaded but no
  device bound: warns correctly, no crash.
- K8 Pro Arch / kernel 6.17.9 with mt7921e PCIe and a non-mt76 USB
  adapter present: existing regex paths catch the PCI side and the
  0e8d:0616 BT-USB interface; new sysfs walk no-ops since no mt76 USB
  driver is loaded. No regression.
- No-hardware laptop run on PTY: warns as before, color escapes
  preserved.

Net effect: +29 lines.