### PR TITLE
install: drop pre-banner 'copy and post' prompt

### DIFF
--- a/install-driver.sh
+++ b/install-driver.sh
@@ -124,12 +124,6 @@ fi
 # ===========================================================================
 # Banner
 # ===========================================================================
-if [ $NO_PROMPT -ne 1 ]; then
-	printf '%s%sPlease copy and post all displayed lines when reporting an issue!%s\n' "${BOLD}" "${YELLOW}" "${NC}"
-	printf "Press Enter to continue..."
-	read -r yn
-fi
-
 printf '\n%s' "${BOLD}"
 printf "  ================================================================\n"
 printf "     mt76 WiFi Driver Installer\n"


### PR DESCRIPTION
Per #32: drops the pre-banner "Please copy and post all displayed lines when reporting an issue! Press Enter to continue..." prompt block from `install-driver.sh`.

`check-driver.sh` now produces a structured diagnostic that the prompt was steering users toward, so the line is dead UX. The `Press Enter` pause also blocks unattended installs (cron, cloud-init, CI runners).

The `NO_PROMPT` detection at the top of the script is kept intact because the post-install prompts at the bottom still rely on it.

Six-line removal, no behaviour change other than the banner now appearing immediately on launch.