### PR TITLE
dkms.conf: drop deprecated CLEAN directive

### DIFF
--- a/dkms.conf
+++ b/dkms.conf
@@ -3,7 +3,6 @@ PACKAGE_VERSION="1.0"
 BUILD_EXCLUSIVE_KERNEL="^(6\.[6-9]\.|6\.1[0-9]\.|7\.)"
 AUTOINSTALL=yes
 MAKE="KVER=${kernelver} 'make' modules"
-CLEAN="KVER=${kernelver} 'make' clean"
 
 # --- Module list ---
 #


### PR DESCRIPTION
dkms-3.4 prints "Deprecated feature: CLEAN" on add and build when
CLEAN is set. The build directory is removed after build, so the
directive is redundant. Deprecated upstream in dkms v3.1.8.

Surfaced on https://github.com/morrownr/mt76/issues/20.