### PR TITLE
Makefile: pass cflags via ccflags-y, not EXTRA_CFLAGS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ ifneq ($(KERNELRELEASE),)
 
 # Bake the git commit into every module for traceability (visible via modinfo)
 GIT_COMMIT := $(shell git --git-dir=$(src)/.git rev-parse --short HEAD 2>/dev/null || echo "unknown")
-EXTRA_CFLAGS += -Werror -DCONFIG_MT76_LEDS -DCONFIG_MT76_DEBUGFS \
+ccflags-y += -Werror -DCONFIG_MT76_LEDS -DCONFIG_MT76_DEBUGFS \
 	-DGIT_COMMIT=\"$(GIT_COMMIT)\"
 
 # --- Core ---


### PR DESCRIPTION
The Kbuild line passes flags via `EXTRA_CFLAGS`, the legacy variable that recent kernels no longer fold into the compile flags (current mainline and the 7.0.x build tree compose cflags from `ccflags-y` only). On those kernels `-Werror`, the `-DCONFIG_MT76_*` defines, and `-DGIT_COMMIT` on that line are silently dropped at build time.

In practice the only one that matters here is `-Werror`: `CONFIG_MT76_LEDS` is a real Kconfig symbol the kernel's own `autoconf.h` already defines (`default y` with MT76_CORE + LEDS_CLASS), and `CONFIG_MT76_DEBUGFS` / `GIT_COMMIT` aren't referenced by any source file. So LEDs and debugfs are unaffected on a normal distro kernel; the visible effect of the dead line is that `-Werror` stops applying.

This switches the line to `ccflags-y`, the supported variable, the same change openwrt/mt76 made in d2b01fbc.

Built clean with `-Werror` active on kernel 7.0.11 (gcc 16) and 7.0.5 (gcc 16): 26 modules each, 0 warnings, 0 errors, with the defines now reaching the compiler.
