### PR TITLE
mt792x: restore < 6.14 compat for mt792x_get_txpower

### DIFF
--- a/mt792x.h
+++ b/mt792x.h
@@ -418,8 +418,13 @@ void mt792x_roc_timer(struct timer_list *timer);
 void mt792x_csa_timer(struct timer_list *timer);
 void mt792x_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		  u32 queues, bool drop);
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 int mt792x_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		       unsigned int link_id, int *dbm);
+#else
+int mt792x_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+		       int *dbm);
+#endif
 int mt792x_assign_vif_chanctx(struct ieee80211_hw *hw,
 			      struct ieee80211_vif *vif,
 			      struct ieee80211_bss_conf *link_conf,

--- a/mt792x_core.c
+++ b/mt792x_core.c
@@ -336,9 +336,16 @@ void mt792x_flush(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 }
 EXPORT_SYMBOL_GPL(mt792x_flush);
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 int mt792x_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 		       unsigned int link_id, int *dbm)
 {
+#else
+int mt792x_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
+		       int *dbm)
+{
+	unsigned int link_id = 0;
+#endif
 	struct mt76_power_limits limits = {};
 	struct ieee80211_bss_conf *link_conf;
 	struct ieee80211_channel *chan;
@@ -348,7 +355,11 @@ int mt792x_get_txpower(struct ieee80211_hw *hw, struct ieee80211_vif *vif,
 	s8 max_power;
 
 	if (!vif)
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 		return mt76_get_txpower(hw, vif, link_id, dbm);
+#else
+		return mt76_get_txpower(hw, vif, dbm);
+#endif
 
 	mvif = (struct mt792x_vif *)vif->drv_priv;
 	phy = mvif->phy->mt76;


### PR DESCRIPTION
`mt792x_get_txpower` gained the `unsigned int link_id` parameter in `8adc84f5` ("wifi: mt76: mt792x: report txpower for the requested vif link"), an upstream patch with the unconditional signature. The `< 6.14` compat gate that already protects `mt76_get_txpower` in `mt76.h` wasn't extended to the `mt792x` wrapper, so the tree builds on >= 6.14 but fails below 6.14:

    mt792x_core.c:351: error: too many arguments to function 'mt76_get_txpower'
    mt792x_core.c:351: error: passing argument 3 ... makes pointer from integer [-Wint-conversion]

This gates `mt792x_get_txpower` (the definition, the `mt76_get_txpower` call, and the prototype) at the same `LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)` boundary `mt76.h` uses. On < 6.14 it drops `link_id` and uses link 0 (deflink), matching the pre-MLO callback signature.

Bisected on a Pi 5 (6.12.47, gcc 14): the parent commit (`cc42fbb`) builds clean, `8adc84f5` breaks it, this PR builds clean again (26 modules). 7.0.11 (gcc 16) unchanged.
