### PR TITLE
wifi: mt76: mt7925: cancel mlo_pm_work on stop

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -2497,10 +2497,19 @@ static void mt7925_channel_switch_rx_beacon(struct ieee80211_hw *hw,
 	}
 }
 
+static void mt7925_stop(struct ieee80211_hw *hw, bool suspend)
+{
+	struct mt792x_dev *dev = mt792x_hw_dev(hw);
+
+	cancel_delayed_work_sync(&dev->mlo_pm_work);
+
+	mt792x_stop(hw, suspend);
+}
+
 const struct ieee80211_ops mt7925_ops = {
 	.tx = mt792x_tx,
 	.start = mt7925_start,
-	.stop = mt792x_stop,
+	.stop = mt7925_stop,
 	.add_interface = mt7925_add_interface,
 	.remove_interface = mt792x_remove_interface,
 	.config = mt7925_config,


### PR DESCRIPTION
Separate bug from the GUI-delay in #28, but I ran into it while poking at that, so it's on its own here.

mt7925 queues a 5 second delayed work (`mlo_pm_work`) during multi-link power-save setup and never cancels it. If the device is torn down inside that window, the timer fires after it is gone and tries to queue onto a workqueue that no longer exists:

```
workqueue: cannot queue mt7925_mlo_pm_work [mt7925_common] on wq phy0
WARNING: kernel/workqueue.c:2283 at __queue_work+0x59/0xa0
```

mt7921 already has its own stop callback, so I gave mt7925 one that cancels the work before calling `mt792x_stop()`. The same `mt7925_ops` backs the PCIe and USB drivers, so it covers both.

I tested it on the mt7925 PCIe card: with a multi-link (MLO) connection up I unbound the device inside the 5 second window, and the stock driver warns on teardown while the patched build stays quiet, with normal teardown unaffected. It also builds on 6.12 through 7.1-rc4.

The path I can't reach here is USB, since the only mt7925 I have is the PCIe card. @Traockl, you've got a USB mt7925u, so if you're up for it: build this, bring up a multi-link (MLO) connection if you can, then tear it down (rmmod or unplug) and check `dmesg` for an `mt7925_mlo_pm_work` warning. With the patch it should stay clean, and even a plain does-it-still-work-on-USB check helps. If it holds up I'll send it to linux-wireless with your Tested-by.
