### PR TITLE
[codex] mt76: preserve non-AC TX queues during Connac PM wake

### DIFF
--- a/mt76_connac.h
+++ b/mt76_connac.h
@@ -95,7 +95,7 @@ struct mt76_connac_pm {
 	struct {
 		struct mt76_wcid *wcid;
 		struct sk_buff *skb;
-	} tx_q[IEEE80211_NUM_ACS];
+	} tx_q[__MT_TXQ_MAX];
 
 	struct work_struct wake_work;
 	wait_queue_head_t wait;

--- a/mt76_connac_mac.c
+++ b/mt76_connac_mac.c
@@ -88,7 +88,7 @@ void mt76_connac_free_pending_tx_skbs(struct mt76_connac_pm *pm,
 	int i;
 
 	spin_lock_bh(&pm->txq_lock);
-	for (i = 0; i < IEEE80211_NUM_ACS; i++) {
+	for (i = 0; i < __MT_TXQ_MAX; i++) {
 		if (wcid && pm->tx_q[i].wcid != wcid)
 			continue;
 
@@ -106,6 +106,11 @@ void mt76_connac_pm_queue_skb(struct ieee80211_hw *hw,
 {
 	int qid = skb_get_queue_mapping(skb);
 	struct mt76_phy *phy = hw->priv;
+
+	if (WARN_ON_ONCE(qid >= __MT_TXQ_MAX)) {
+		dev_kfree_skb(skb);
+		return;
+	}
 
 	spin_lock_bh(&pm->txq_lock);
 	if (!pm->tx_q[qid].skb) {
@@ -126,7 +131,7 @@ void mt76_connac_pm_dequeue_skbs(struct mt76_phy *phy,
 	int i;
 
 	spin_lock_bh(&pm->txq_lock);
-	for (i = 0; i < IEEE80211_NUM_ACS; i++) {
+	for (i = 0; i < __MT_TXQ_MAX; i++) {
 		struct mt76_wcid *wcid = pm->tx_q[i].wcid;
 		struct ieee80211_sta *sta = NULL;
 

--- a/mt792x_core.c
+++ b/mt792x_core.c
@@ -92,7 +92,6 @@ void mt792x_tx(struct ieee80211_hw *hw, struct ieee80211_tx_control *control,
 	struct ieee80211_vif *vif = info->control.vif;
 	struct mt76_wcid *wcid = &dev->mt76.global_wcid;
 	u8 link_id;
-	int qid;
 
 	if (control->sta) {
 		struct mt792x_link_sta *mlink;
@@ -134,12 +133,6 @@ void mt792x_tx(struct ieee80211_hw *hw, struct ieee80211_tx_control *control,
 		mt76_tx(mphy, control->sta, wcid, skb);
 		mt76_connac_pm_unref(mphy, &dev->pm);
 		return;
-	}
-
-	qid = skb_get_queue_mapping(skb);
-	if (qid >= MT_TXQ_PSD) {
-		qid = IEEE80211_AC_BE;
-		skb_set_queue_mapping(skb, qid);
 	}
 
 	mt76_connac_pm_queue_skb(hw, &dev->pm, wcid, skb);


### PR DESCRIPTION
Preserve non-AC TX queue mapping in the shared Connac PM wake path by widening the pending TX tracking to __MT_TXQ_MAX and keeping mt7925/mt7921 queue handling intact.

This is split out from the MT7927 rework and stays on the shared mt76/mt792x path so it can be reviewed against the existing mt7925 direction instead of a standalone mt7927 driver.

Validation:
  - make -j4
