### PR TITLE
[codex] mt76: parse MT7927 MLO EML capabilities

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -284,6 +284,11 @@ int mt7925_init_mlo_caps(struct mt792x_phy *phy)
 	ext_capab[0].eml_capabilities = phy->eml_cap;
 	ext_capab[0].mld_capa_and_ops =
 		u16_encode_bits(0, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS);
+	if (is_mt7927(phy->mt76->dev)) {
+		ext_capab[0].mld_capa_and_ops =
+			u16_encode_bits(1, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS) |
+			IEEE80211_MLD_CAP_OP_FREQ_SEP_TYPE_IND;
+	}
 
 	wiphy->flags |= WIPHY_FLAG_SUPPORTS_MLO;
 	wiphy->iftype_ext_capab = ext_capab;

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -1055,6 +1055,9 @@ mt7925_mcu_get_nic_capability(struct mt792x_dev *dev)
 		}
 		skb_pull(skb, len);
 	}
+
+	if (is_mt7927(&dev->mt76))
+		dev->phy.chip_cap |= MT792x_CHIP_CAP_MLO_EN;
 out:
 	dev_kfree_skb(skb);
 	return ret;
@@ -2722,12 +2725,9 @@ mt7925_mcu_bss_mld_tlv(struct sk_buff *skb,
 	mld->own_mld_id = mconf->mt76.idx + 32;
 	mld->remap_idx = 0xff;
 
-	if (phy->chip_cap & MT792x_CHIP_CAP_MLO_EML_EN) {
-		mld->eml_enable = !!(link_conf->vif->cfg.eml_cap &
-				     IEEE80211_EML_CAP_EMLSR_SUPP);
-	} else {
-		mld->eml_enable = 0;
-	}
+	mld->eml_enable = !!(phy->chip_cap & MT792x_CHIP_CAP_MLO_EML_EN) &&
+			  !!(link_conf->vif->cfg.eml_cap &
+			     IEEE80211_EML_CAP_EMLSR_SUPP);
 
 	memcpy(mld->mac_addr, vif->addr, ETH_ALEN);
 }


### PR DESCRIPTION
Keep the MT7925 MLO path aware of the MT7927 EML capability shape, with MT7927-gated capability parsing and negotiated EMLSR handling inside the existing mt7925 code path.

This follows the same upstream direction as the other mt7925-based MT7927 work rather than a standalone mt7927 module.

Validation:
  - make -j4
  - one active associated 6 GHz / 320 MHz MLO link on fresh reboot
