### PR TITLE
[codex] mt7927: stabilize monitor lifecycle

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ install:
 		zstd -fq --rm $(MODDIR)/*.ko 2>/dev/null || true; \
 	elif ls /lib/modules/$(KVER)/kernel/net/wireless/*.ko.xz >/dev/null 2>&1; then \
 		echo "Compressing modules with xz (matching distro scheme)..."; \
-		xz -f $(MODDIR)/*.ko 2>/dev/null || true; \
+		xz -f -C crc32 $(MODDIR)/*.ko 2>/dev/null || true; \
 	elif ls /lib/modules/$(KVER)/kernel/net/wireless/*.ko.gz >/dev/null 2>&1; then \
 		echo "Compressing modules with gzip (matching distro scheme)..."; \
 		gzip -f $(MODDIR)/*.ko 2>/dev/null || true; \

--- a/mt7925/mac.c
+++ b/mt7925/mac.c
@@ -406,6 +406,13 @@ mt7925_mac_fill_rx(struct mt792x_dev *dev, struct sk_buff *skb)
 
 	mt792x_get_status_freq_info(status, chfreq);
 
+	/* MT7927 reports frames from both DBDC RX chains in monitor mode. */
+	if (is_mt7927(&dev->mt76) &&
+	    (mphy->hw->conf.flags & IEEE80211_CONF_MONITOR) &&
+	    phy->mt76->chandef.chan &&
+	    status->freq != phy->mt76->chandef.chan->center_freq)
+		return -EINVAL;
+
 	switch (status->band) {
 	case NL80211_BAND_5GHZ:
 		sband = &mphy->sband_5g.sband;

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -789,6 +789,9 @@ mt7925_monitor_update_chan(struct mt792x_vif *mvif,
 	if (!chan)
 		return;
 
+	if (ctx)
+		mvif->phy->mt76->chandef = ctx->def;
+
 	mconf->mt76.band_idx = mt7927_band_idx(chan->band);
 	mconf->mt76.basic_rates_idx = MT792x_BASIC_RATES_TBL;
 	if (chan->band != NL80211_BAND_2GHZ)
@@ -808,6 +811,10 @@ mt7925_sniffer_interface_iter(void *priv, u8 *mac, struct ieee80211_vif *vif)
 					   NULL);
 
 	mt7925_mcu_set_sniffer(dev, vif, monitor);
+	if (monitor && is_mt7927(&dev->mt76) &&
+	    dev->phy.mt76->chandef.chan)
+		mt7925_mcu_config_sniffer((struct mt792x_vif *)vif->drv_priv,
+					   NULL);
 	pm->enable = pm->enable_user && !monitor;
 	pm->ds_enable = pm->ds_enable_user && !monitor;
 
@@ -884,6 +891,11 @@ static void mt7925_configure_filter(struct ieee80211_hw *hw,
 
 	mt792x_mutex_acquire(dev);
 	mt7925_mcu_set_rxfilter(dev, flags, 0, 0);
+	if (is_mt7927(&dev->mt76) &&
+	    (hw->conf.flags & IEEE80211_CONF_MONITOR))
+		ieee80211_iterate_active_interfaces(hw,
+					    IEEE80211_IFACE_ITER_RESUME_ALL,
+					    mt7925_sniffer_interface_iter, dev);
 	mt792x_mutex_release(dev);
 
 	*total_flags &= (FIF_OTHER_BSS | FIF_FCSFAIL | FIF_CONTROL);
@@ -1998,6 +2010,11 @@ mt7925_change_chanctx(struct ieee80211_hw *hw,
 
 	mt792x_mutex_acquire(phy->dev);
 	if (vif->type == NL80211_IFTYPE_MONITOR) {
+		if (is_mt7927(&phy->dev->mt76) &&
+		    phy->mt76->chandef.chan &&
+		    mt7927_band_idx(phy->mt76->chandef.chan->band) !=
+		    mt7927_band_idx(ctx->def.chan->band))
+			mt7925_mcu_set_sniffer(mvif->phy->dev, vif, false);
 		mt7925_monitor_update_chan(mvif, ctx);
 		mt7925_mcu_set_sniffer(mvif->phy->dev, vif, true);
 		mt7925_mcu_config_sniffer(mvif, ctx);

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -804,17 +804,19 @@ mt7925_sniffer_interface_iter(void *priv, u8 *mac, struct ieee80211_vif *vif)
 	struct mt792x_dev *dev = priv;
 	struct ieee80211_hw *hw = mt76_hw(dev);
 	struct mt76_connac_pm *pm = &dev->pm;
+	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
+	struct ieee80211_chanctx_conf *ctx = mvif->bss_conf.mt76.ctx;
 	bool monitor = !!(hw->conf.flags & IEEE80211_CONF_MONITOR);
 
+	if (monitor && !ctx)
+		return;
+
 	if (monitor)
-		mt7925_monitor_update_chan((struct mt792x_vif *)vif->drv_priv,
-					   NULL);
+		mt7925_monitor_update_chan(mvif, ctx);
 
 	mt7925_mcu_set_sniffer(dev, vif, monitor);
-	if (monitor && is_mt7927(&dev->mt76) &&
-	    dev->phy.mt76->chandef.chan)
-		mt7925_mcu_config_sniffer((struct mt792x_vif *)vif->drv_priv,
-					   NULL);
+	if (monitor && is_mt7927(&dev->mt76))
+		mt7925_mcu_config_sniffer(mvif, ctx);
 	pm->enable = pm->enable_user && !monitor;
 	pm->ds_enable = pm->ds_enable_user && !monitor;
 
@@ -2012,6 +2014,7 @@ mt7925_change_chanctx(struct ieee80211_hw *hw,
 	if (vif->type == NL80211_IFTYPE_MONITOR) {
 		if (is_mt7927(&phy->dev->mt76) &&
 		    phy->mt76->chandef.chan &&
+		    ctx->def.chan &&
 		    mt7927_band_idx(phy->mt76->chandef.chan->band) !=
 		    mt7927_band_idx(ctx->def.chan->band))
 			mt7925_mcu_set_sniffer(mvif->phy->dev, vif, false);

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -3980,6 +3980,9 @@ int mt7925_mcu_set_rxfilter(struct mt792x_dev *dev, u32 fif,
 		.bit_op = bit_op,
 	};
 
+	if (is_mt7927(&dev->mt76) && phy->mt76->chandef.chan)
+		req.band_idx = mt7927_band_idx(phy->mt76->chandef.chan->band);
+
 	return mt76_mcu_send_msg(&phy->dev->mt76, MCU_UNI_CMD(BAND_CONFIG),
 				 &req, sizeof(req), true);
 }


### PR DESCRIPTION
Stabilizes MT7927 monitor mode after repeated filter transitions and channel changes.\n\nWhat changed:\n- re-arm the MT7927 sniffer path after filter updates so monitor mode keeps producing frames across repeated capture runs\n- keep the MT7927 monitor chandef in sync with the active channel context\n- reject stale monitor frames whose reported frequency does not match the active MT7927 chandef\n- propagate the active MT7927 band index into the shared RX filter path\n- keep module install compression compatible with distros that store modules as *.ko.xz\n\nWhy:\n- this fixes the monitor lifecycle regression that showed up after the 7.0.12+deb13-amd64 kernel upgrade, where the card could enter monitor mode but stop producing useful RX after repeated open/close cycles\n\nValidation:\n- built successfully on 7.0.12+deb13-amd64