### PR TITLE
wifi: mt76: mt7925: stop advertising MT7927 STR fallback

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -284,11 +284,6 @@ int mt7925_init_mlo_caps(struct mt792x_phy *phy)
 	ext_capab[0].eml_capabilities = phy->eml_cap;
 	ext_capab[0].mld_capa_and_ops =
 		u16_encode_bits(0, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS);
-	if (is_mt7927(phy->mt76->dev)) {
-		ext_capab[0].mld_capa_and_ops =
-			u16_encode_bits(1, IEEE80211_MLD_CAP_OP_MAX_SIMUL_LINKS) |
-			IEEE80211_MLD_CAP_OP_FREQ_SEP_TYPE_IND;
-	}
 
 	wiphy->flags |= WIPHY_FLAG_SUPPORTS_MLO;
 	wiphy->iftype_ext_capab = ext_capab;


### PR DESCRIPTION
## Summary

- stop the MT7927 fallback from advertising simultaneous-link and frequency-separation capabilities that firmware does not report
- keep MT7927 MLO enabled through the existing chip-capability fallback
- leave the documented EML capability parsing and monitor-mode paths unchanged

## Root cause

The MT7927 fallback set `MAX_SIMUL_LINKS` and `FREQ_SEP_TYPE_IND` even though the firmware capability data does not report STR support. That caused MLO remain-on-channel setup to select the JOIN/DBDC request path. Firmware granted the first two-link session after reset, then stopped granting identical requests during immediate reconnects, leading to control-port failures and four-way handshake timeouts.

Keeping the default zero `MAX_SIMUL_LINKS` value selects the MLSR ROC request with automatic band selection while preserving MLO support.

## Validation

- built successfully against Linux `7.0.12+deb13-amd64`
- completed two immediate 90-second MLO sessions and one 60-second session after a monitor-mode transition
- every run reported `valid_links=0x3` with links on 2422 MHz and 5260 MHz
- both links installed GTK and IGTK keys
- no unexpected disconnects, control-port failures, four-way handshake timeouts, firmware resets, warnings, or crashes occurred in the run deltas
- monitor/injection regression: 993 packets on 2.4 GHz and 8,228 packets on 5 GHz with zero kernel drops; active probes received responses on both bands

This validates repeat two-link MLSR operation. It does not claim unsupported simultaneous STR operation.
