### PR TITLE
wifi: mt76: mt7925: re-arm MT7927 sniffer on channel changes

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -789,6 +789,9 @@ mt7925_monitor_update_chan(struct mt792x_vif *mvif,
 	if (!chan)
 		return;
 
+	if (ctx)
+		mvif->phy->mt76->chandef = ctx->def;
+
 	mconf->mt76.band_idx = mt7927_band_idx(chan->band);
 	mconf->mt76.basic_rates_idx = MT792x_BASIC_RATES_TBL;
 	if (chan->band != NL80211_BAND_2GHZ)
@@ -801,13 +804,19 @@ mt7925_sniffer_interface_iter(void *priv, u8 *mac, struct ieee80211_vif *vif)
 	struct mt792x_dev *dev = priv;
 	struct ieee80211_hw *hw = mt76_hw(dev);
 	struct mt76_connac_pm *pm = &dev->pm;
+	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
+	struct ieee80211_chanctx_conf *ctx = mvif->bss_conf.mt76.ctx;
 	bool monitor = !!(hw->conf.flags & IEEE80211_CONF_MONITOR);
 
+	if (monitor && !ctx)
+		return;
+
 	if (monitor)
-		mt7925_monitor_update_chan((struct mt792x_vif *)vif->drv_priv,
-					   NULL);
+		mt7925_monitor_update_chan(mvif, ctx);
 
 	mt7925_mcu_set_sniffer(dev, vif, monitor);
+	if (monitor && is_mt7927(&dev->mt76))
+		mt7925_mcu_config_sniffer(mvif, ctx);
 	pm->enable = pm->enable_user && !monitor;
 	pm->ds_enable = pm->ds_enable_user && !monitor;
 
@@ -884,6 +893,11 @@ static void mt7925_configure_filter(struct ieee80211_hw *hw,
 
 	mt792x_mutex_acquire(dev);
 	mt7925_mcu_set_rxfilter(dev, flags, 0, 0);
+	if (is_mt7927(&dev->mt76) &&
+	    (hw->conf.flags & IEEE80211_CONF_MONITOR))
+		ieee80211_iterate_active_interfaces(hw,
+					    IEEE80211_IFACE_ITER_RESUME_ALL,
+					    mt7925_sniffer_interface_iter, dev);
 	mt792x_mutex_release(dev);
 
 	*total_flags &= (FIF_OTHER_BSS | FIF_FCSFAIL | FIF_CONTROL);
@@ -1998,6 +2012,12 @@ mt7925_change_chanctx(struct ieee80211_hw *hw,
 
 	mt792x_mutex_acquire(phy->dev);
 	if (vif->type == NL80211_IFTYPE_MONITOR) {
+		if (is_mt7927(&phy->dev->mt76) &&
+		    phy->mt76->chandef.chan &&
+		    ctx->def.chan &&
+		    mt7927_band_idx(phy->mt76->chandef.chan->band) !=
+		    mt7927_band_idx(ctx->def.chan->band))
+			mt7925_mcu_set_sniffer(mvif->phy->dev, vif, false);
 		mt7925_monitor_update_chan(mvif, ctx);
 		mt7925_mcu_set_sniffer(mvif->phy->dev, vif, true);
 		mt7925_mcu_config_sniffer(mvif, ctx);


### PR DESCRIPTION
## Summary

- re-arm the MT7927 sniffer from the active monitor channel context
- reconfigure the sniffer when monitor filtering is reapplied
- stop the sniffer before crossing MT7927 physical sniffer bands, then restart it on the new context

## Scope

This is the minimal `mt7925/main.c` re-arm change requested after the A/B testing on PR #51. It intentionally excludes the experimental `mt7925/mac.c` DBDC frequency filter because that filter can discard frames from the other RX chain. There are no Makefile or `mt7925/mcu.c` changes.

## Reason

Repeated monitor transitions between 5 GHz and 2.4 GHz can leave MT7927 receiving packets at the packet socket while hcxdumptool no longer decodes APs or transmits active probes. Re-arming from the active channel context keeps the sniffer configuration synchronized across those transitions.

## Validation

- the `mt7925/main.c` delta matches the re-arm logic tested at commit `4a86e856ad4603843e80af1cf4cf4750aa665a4f`
- `make -j$(nproc)` passes against Linux `7.0.12+deb13-amd64`
- Lucid-Duck's hardware A/B on MT7927 reproduced the failure on the merged base and kept all eight 5 GHz/2.4 GHz transition cycles healthy with this re-arm logic, including 2.4 GHz probe requests and responses
