### PR TITLE
wifi: mt76: restrict NPU/PPE active checks to MMIO devices

### DIFF
--- a/mt76.h
+++ b/mt76.h
@@ -1760,12 +1760,12 @@ static inline int mt76_npu_send_txrx_addr(struct mt76_dev *dev, int ifindex,
 
 static inline bool mt76_npu_device_active(struct mt76_dev *dev)
 {
-	return !!rcu_access_pointer(dev->mmio.npu);
+	return mt76_is_mmio(dev) && !!rcu_access_pointer(dev->mmio.npu);
 }
 
 static inline bool mt76_ppe_device_active(struct mt76_dev *dev)
 {
-	return !!rcu_access_pointer(dev->mmio.ppe_dev);
+	return mt76_is_mmio(dev) && !!rcu_access_pointer(dev->mmio.ppe_dev);
 }
 
 static inline int mt76_npu_send_msg(struct airoha_npu *npu, int ifindex,


### PR DESCRIPTION
Fixes the AP-mode retransmits in #56.

The NPU offload check reads a union field that only means something on the PCIe/SoC parts. On USB it reads leftover data from the usb struct and comes back true, so the driver skips RX reordering and TCP sees the out-of-order frames as loss. Gating the check on mt76_is_mmio() fixes it.

Tested on a Pi 5 (kernel 6.18) against this repo at c877e060, stock vs patched. TCP retransmits per 10s:

| adapter | with the bug | with the fix |
|---------|--------------|--------------|
| mt7921u | 20 - 71      | 0            |
| mt7612u | 288 - 824    | 0            |
| mt7610u | 76 - 251     | 0            |
| mt7925u | 2 - 5        | 0            |

mt7925u was measured as a client (its AP mode has a separate crash, unrelated to this one). I also checked a PCIe card (mt7922): identical before and after, since the patch does nothing on mmio.

The bad commit is in mainline too (6.19), so this probably wants to go upstream as well. I'd rather land it here and let it soak first.
