### PR TITLE
wifi: mt76: mt7925: ensure tx headroom in usb_sdio_tx_prepare_skb

### DIFF
--- a/mt7925/mac.c
+++ b/mt7925/mac.c
@@ -1435,6 +1435,10 @@ int mt7925_usb_sdio_tx_prepare_skb(struct mt76_dev *mdev, void *txwi_ptr,
 	if (!wcid)
 		wcid = &dev->mt76.global_wcid;
 
+	if (skb_headroom(skb) < MT_SDIO_TXD_SIZE + MT_SDIO_HDR_SIZE &&
+	    skb_cow_head(skb, MT_SDIO_TXD_SIZE + MT_SDIO_HDR_SIZE))
+		return -ENOMEM;
+
 	if (sta) {
 		struct mt792x_sta *msta = (struct mt792x_sta *)sta->drv_priv;
 


### PR DESCRIPTION
This fixes the mt7925u AP crash in #52: an mt7925 USB adapter used as an AP reboots the machine when a connected client's traffic is forwarded.

The cause is a missing tx headroom reservation. `mt7925_usb_sdio_tx_prepare_skb()` prepends a TX descriptor plus a USB header (68 bytes) with `skb_push`. That headroom normally comes from `hw->extra_tx_headroom`, but forwarded data frames take the 802.3 encap-offload path (`ieee80211_8023_xmit`), which does not reserve it. The frame arrives 4 bytes short, `skb_push` underflows, and `skb_under_panic` reboots the box. Locally generated frames carry the slack and survive, so it shows up as a crash on the first forwarded frame after a client joins.

The fix grows the headroom with `skb_cow_head`, only for frames that are short, so it is a no-op on the common path.

Verified on hardware, Netgear A9000 (mt7925u) as a hostapd AP on a Pi 5 (RasPiOS 6.18.34):

- Stock: a bridged AP panics on client DHCP, 2 for 2. The captured trace matches the #52 reporter's oops on an Asus TUF AX4200 (OpenWrt 6.12.74), same function and the same 4-byte underflow.
- Patched: the same bridged AP takes association, DHCP, three reconnects and a forwarded ping flood with no panic.
- No regression: a matched same-session A/B on an isolated (non-forwarding) AP shows the same throughput stock versus patched.

The same code path is in the upstream mt7925 driver, so I will follow up with this to linux-wireless. Opening here first since the reporter and testers are on this repo.
