### PR TITLE
wifi: mt76: mt7925: fix build against kernel 7.2 EML mask renames

### DIFF
--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -8,6 +8,14 @@
 #include "mcu.h"
 #include "mac.h"
 
+/* compat: kernel 7.2 renamed the EML delay masks (EMLSR_ -> EML_);
+ * the values are unchanged.
+ */
+#ifndef IEEE80211_EML_CAP_EML_PADDING_DELAY
+#define IEEE80211_EML_CAP_EML_PADDING_DELAY	IEEE80211_EML_CAP_EMLSR_PADDING_DELAY
+#define IEEE80211_EML_CAP_EML_TRANSITION_DELAY	IEEE80211_EML_CAP_EMLSR_TRANSITION_DELAY
+#endif
+
 #define MT_STA_BFER			BIT(0)
 #define MT_STA_BFEE			BIT(1)
 
@@ -1958,8 +1966,8 @@ mt7925_mcu_sta_eht_mld_tlv(struct sk_buff *skb,
 
 	eml_cap = (vif->cfg.eml_cap & (IEEE80211_EML_CAP_EMLSR_SUPP |
 				       IEEE80211_EML_CAP_TRANSITION_TIMEOUT)) |
-		  (ext_capa->eml_capabilities & (IEEE80211_EML_CAP_EMLSR_PADDING_DELAY |
-						IEEE80211_EML_CAP_EMLSR_TRANSITION_DELAY));
+		  (ext_capa->eml_capabilities & (IEEE80211_EML_CAP_EML_PADDING_DELAY |
+						IEEE80211_EML_CAP_EML_TRANSITION_DELAY));
 
 	if (eml_cap & IEEE80211_EML_CAP_EMLSR_SUPP) {
 		eht_mld->eml_cap[0] = u16_get_bits(eml_cap, GENMASK(7, 0));


### PR DESCRIPTION
Main does not build against 7.2-rc kernels. @TheKing349 reported it in #20 on CachyOS 7.2.0-rc3:

```
mt7925/mcu.c:1961:36: error: use of undeclared identifier 'IEEE80211_EML_CAP_EMLSR_PADDING_DELAY'
mt7925/mcu.c:1962:7: error: use of undeclared identifier 'IEEE80211_EML_CAP_EMLSR_TRANSITION_DELAY'
```

Kernel 7.2 renamed these two masks in ieee80211-eht.h (torvalds/linux@5858f5e1588f, "wifi: Rename EMLSR delay constants and add EMLMR helpers and definitions"). The mask values did not change (0x000e and 0x0070 before and after). mt7925/mcu.c is the only file in this tree that used the old names; EMLSR_SUPP and TRANSITION_TIMEOUT were not renamed and are unaffected.

The fix switches the two lines to the new names, which makes them match the in-kernel mt7925 driver, and aliases the new names at the top of the file for pre-7.2 kernels. I used `#ifndef` on the new name rather than a kernel version check so a distro that backports the rename cannot hit a double definition.

Build-tested in all four combinations (Fedora 44, gcc 16.1.1):

| tree | 7.1.3 headers | 7.2-rc3 headers |
| --- | --- | --- |
| main (86fe578) | clean, zero warnings | fails on exactly the two identifiers above |
| this PR | clean, zero warnings | clean, all 26 modules build |

My repro is gcc, so the wording differs from the clang output above, but it is the same two identifiers on the same two lines, and gcc even suggests the renamed names.

On 7.1.3 the patched mt7925/mcu.o disassembles identically to main's, so nothing changes on the kernels people run today. The 7.2-rc3 build was against a modules_prepare tree, so modpost could not resolve symbols that live in vmlinux or mac80211; I checked every symbol it flagged and all of them exist as exports in the 7.2-rc3 source. Not runtime-tested on a booted 7.2 kernel.

With this in, anyone testing monitor mode on 7.2-rc per #18 can build main again.
