### PR TITLE
wifi: mt76: mt7925: remove duplicate mt7925_stop()

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -2563,15 +2563,6 @@ static void mt7925_stop(struct ieee80211_hw *hw, bool suspend)
 	mt792x_stop(hw, suspend);
 }
 
-static void mt7925_stop(struct ieee80211_hw *hw, bool suspend)
-{
-	struct mt792x_dev *dev = mt792x_hw_dev(hw);
-
-	cancel_delayed_work_sync(&dev->mlo_pm_work);
-
-	mt792x_stop(hw, suspend);
-}
-
 const struct ieee80211_ops mt7925_ops = {
 	.tx = mt792x_tx,
 	.start = mt7925_start,


### PR DESCRIPTION
mt7925/main.c has two identical mt7925_stop() definitions, so the build fails:

```
mt7925/main.c:2566:13: error: redefinition of 'mt7925_stop'
mt7925/main.c:2557:13: note: previous definition of 'mt7925_stop' was here
```

The tree already carried mt7925_stop() from the earlier mlo_pm_work backport (PR #44); the cherry-pick landed the now-upstream version of the same fix on top, adding a second, byte-identical copy. Drop the duplicate. mt7925_ops.stop still resolves to the remaining definition.

Build tested on 7.0.5: stock reproduces the redefinition; with this patch mt7925/main.o and the full mt7925 module set (mt7925_common/e/u_git.ko) build clean.
