### PR TITLE
wifi: mt76: mt792x: fix use-after-free in mt76_rx_poll_complete

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -2563,6 +2563,40 @@ static void mt7925_stop(struct ieee80211_hw *hw, bool suspend)
 	mt792x_stop(hw, suspend);
 }
 
+static void mt7925_sta_pre_rcu_remove(struct ieee80211_hw *hw,
+				      struct ieee80211_vif *vif,
+				      struct ieee80211_sta *sta)
+{
+	struct mt76_phy *phy = hw->priv;
+	struct mt76_dev *dev = phy->dev;
+	struct mt76_wcid *wcid = (struct mt76_wcid *)sta->drv_priv;
+
+	mutex_lock(&dev->mutex);
+	spin_lock_bh(&dev->status_lock);
+
+	if (ieee80211_vif_is_mld(vif)) {
+		struct mt792x_sta *msta = (struct mt792x_sta *)sta->drv_priv;
+		struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
+		unsigned long valid = mvif->valid_links;
+		struct mt792x_link_sta *mlink;
+		unsigned int link_id;
+
+		for_each_set_bit(link_id, &valid, IEEE80211_MLD_MAX_NUM_LINKS) {
+			mlink = mt792x_sta_to_link(msta, link_id);
+			if (!mlink || !mlink->wcid.sta)
+				continue;
+			if (mlink->wcid.idx < ARRAY_SIZE(dev->wcid))
+				rcu_assign_pointer(dev->wcid[mlink->wcid.idx],
+						   NULL);
+		}
+	} else {
+		rcu_assign_pointer(dev->wcid[wcid->idx], NULL);
+	}
+
+	spin_unlock_bh(&dev->status_lock);
+	mutex_unlock(&dev->mutex);
+}
+
 const struct ieee80211_ops mt7925_ops = {
 	.tx = mt792x_tx,
 	.start = mt7925_start,
@@ -2575,7 +2609,7 @@ const struct ieee80211_ops mt7925_ops = {
 	.start_ap = mt7925_start_ap,
 	.stop_ap = mt7925_stop_ap,
 	.sta_state = mt76_sta_state,
-	.sta_pre_rcu_remove = mt76_sta_pre_rcu_remove,
+	.sta_pre_rcu_remove = mt7925_sta_pre_rcu_remove,
 	.set_key = mt7925_set_key,
 	.sta_set_decap_offload = mt7925_sta_set_decap_offload,
 #if IS_ENABLED(CONFIG_IPV6)


### PR DESCRIPTION
Port of openwrt/mt76 491d786c (Eason Lai). It bounced in the cherry-pick wave on placement only: upstream inserts the new mt7925_sta_pre_rcu_remove() at the spot where this tree keeps mt7925_stop() from PR #44. No functional collision; the ops-table line merges on its own.

What it fixes: the generic mt76_sta_pre_rcu_remove() clears only the station's primary wcid from dev->wcid[]. For an MLD station the per-link wcids stay populated after the station is freed, and mt76_rx_poll_complete can dereference them. The new handler clears every valid link's wcid under status_lock before the RCU removal.

Cherry-picked with -x, authorship preserved, conflict resolved by keeping mt7925_stop() and inserting the new function after it. Build tested on 7.0.5: full make clean, mt7925_common/e/u_git.ko all build.
