### PR TITLE
wifi: mt76: mt7927: set band index for sniffer mode

### DIFF
--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -2246,7 +2246,8 @@ int mt7925_get_txpwr_info(struct mt792x_dev *dev, u8 band_idx, struct mt7925_txp
 int mt7925_mcu_set_sniffer(struct mt792x_dev *dev, struct ieee80211_vif *vif,
 			   bool enable)
 {
-	struct ieee80211_channel *chan = dev->phy.mt76->chandef.chan;
+	struct mt792x_vif *mvif = (struct mt792x_vif *)vif->drv_priv;
+	struct ieee80211_chanctx_conf *ctx = mvif->bss_conf.mt76.ctx;
 	struct {
 		struct {
 			u8 band_idx;
@@ -2269,8 +2270,14 @@ int mt7925_mcu_set_sniffer(struct mt792x_dev *dev, struct ieee80211_vif *vif,
 		},
 	};
 
-	if (is_mt7927(&dev->mt76) && chan)
-		req.hdr.band_idx = mt7927_band_idx(chan->band);
+	if (is_mt7927(&dev->mt76)) {
+		struct ieee80211_channel *chan;
+
+		chan = ctx ? ctx->def.chan : mvif->phy->mt76->chandef.chan;
+
+		if (chan)
+			req.hdr.band_idx = mt7927_band_idx(chan->band);
+	}
 
 	return mt76_mcu_send_msg(&dev->mt76, MCU_UNI_CMD(SNIFFER), &req, sizeof(req),
 				 true);
@@ -2331,7 +2338,7 @@ int mt7925_mcu_config_sniffer(struct mt792x_vif *vif,
 		},
 	};
 
-	if (is_mt7927(&vif->phy->dev->mt76))
+	if (is_mt7927(mphy->dev))
 		req.hdr.band_idx = mt7927_band_idx(chandef->chan->band);
 
 	if (chandef->chan->band < ARRAY_SIZE(ch_band))


### PR DESCRIPTION
Re-sync of the MT7927 sniffer band handling to the upstream copy (openwrt/mt76 7274d6cc, Sean Wang). #48 fixed the same thing first with a local variant in mcu.c, which is why 7274d6cc would not apply during the wave, the same local-variant situation that produced the duplicate mt7925_stop().

Net change: mt7925_mcu_set_sniffer() reads the channel from the vif's chanctx when present, falling back to the phy chandef, instead of the phy chandef only, and both sniffer functions end up byte-identical to upstream so this spot stops conflicting on future cherry-picks. #48's main.c monitor plumbing (mt7925_monitor_update_chan and the assign_vif_chanctx band/phy_idx assignments) has no upstream counterpart and is untouched here.

Cherry-picked with -x, authorship preserved. Build tested on 7.0.5: full make clean, mt7925_common/e/u_git.ko all build.
