### PR TITLE
wifi: mt76: mt7925 + mt7615: drop TXRX_NOTIFY on non-mmio buses

### DIFF
--- a/mt7615/mac.c
+++ b/mt7615/mac.c
@@ -1601,6 +1601,8 @@ bool mt7615_rx_check(struct mt76_dev *mdev, void *data, int len)
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
+		if (!mt76_is_mmio(mdev))
+			return false;
 		mt7615_mac_tx_free(dev, data, len);
 		return false;
 	case PKT_TYPE_TXS:
@@ -1634,6 +1636,10 @@ void mt7615_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,
 		dev_kfree_skb(skb);
 		break;
 	case PKT_TYPE_TXRX_NOTIFY:
+		if (!mt76_is_mmio(mdev)) {
+			dev_kfree_skb(skb);
+			break;
+		}
 		mt7615_mac_tx_free(dev, skb->data, skb->len);
 		dev_kfree_skb(skb);
 		break;

--- a/mt7925/mac.c
+++ b/mt7925/mac.c
@@ -1410,8 +1410,9 @@ bool mt7925_rx_check(struct mt76_dev *mdev, void *data, int len)
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
-		/* PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices */
-		mt7925_mac_tx_free(dev, data, len); /* mmio */
+		if (!mt76_is_mmio(mdev))
+			return false;
+		mt7925_mac_tx_free(dev, data, len);
 		return false;
 	case PKT_TYPE_TXS:
 		for (rxd += 4; rxd + 12 <= end; rxd += 12)
@@ -1447,7 +1448,10 @@ void mt7925_queue_rx_skb(struct mt76_dev *mdev, enum mt76_rxq_id q,
 
 	switch (type) {
 	case PKT_TYPE_TXRX_NOTIFY:
-		/* PKT_TYPE_TXRX_NOTIFY can be received only by mmio devices */
+		if (!mt76_is_mmio(mdev)) {
+			napi_consume_skb(skb, 1);
+			break;
+		}
 		mt7925_mac_tx_free(dev, skb->data, skb->len);
 		napi_consume_skb(skb, 1);
 		break;


### PR DESCRIPTION
The two TXRX_NOTIFY guards from the #32 list, ported as offered. mt7921 already came in through PR #7, so this completes the set: upstream these three were one series, patches 2, 3 and 4 of `20260627191336.20223`, and mainline now carries all of them as `da4082e91aca`, `feeff151c83e` and `39afc46c0243`.

What they fix: `PKT_TYPE_TXRX_NOTIFY` is an mmio-only event, but `mt7925_rx_check()` / `mt7925_queue_rx_skb()` and their mt7615 counterparts dispatch it to `*_mac_tx_free()` on every bus. That path cleans the DMA tx queues through `queue_ops->tx_cleanup()`, which only the mmio queue ops implement. On USB and SDIO it is NULL, so the event calls a NULL pointer from the RX worker. Both commits drop the event via `mt76_is_mmio()`, the same shape as Lorenzo's `5683e1488aa9`. In this tree that reaches `mt7925u_git.ko` and `mt7663u_git.ko` / `mt7663s_git.ko`.

The mt7925 case label has been there since the driver landed (`2afc7285` here, `c948b5da6bbe` upstream), which is why this looks like a no-op at a glance. It is not: the label existed, the bus check never did.

Cherry-picked with `-x`, authorship and the upstream `Signed-off-by`/`Link` trailers preserved. Both diffs are line-identical to the mainline commits. Build tested on 7.1.5 against today's main after your cherry-pick wave: clean rebase, no conflicts, full `make clean` then full build, 26 modules. checkpatch `--strict` clean on both.
