### PR TITLE
Makefile: use xz --check=crc32 for compressed module install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -151,7 +151,7 @@ install:
 		zstd -fq --rm $(MODDIR)/*.ko 2>/dev/null || true; \
 	elif ls /lib/modules/$(KVER)/kernel/net/wireless/*.ko.xz >/dev/null 2>&1; then \
 		echo "Compressing modules with xz (matching distro scheme)..."; \
-		xz -f $(MODDIR)/*.ko 2>/dev/null || true; \
+		xz --check=crc32 -f $(MODDIR)/*.ko 2>/dev/null || true; \
 	elif ls /lib/modules/$(KVER)/kernel/net/wireless/*.ko.gz >/dev/null 2>&1; then \
 		echo "Compressing modules with gzip (matching distro scheme)..."; \
 		gzip -f $(MODDIR)/*.ko 2>/dev/null || true; \


### PR DESCRIPTION
Split out of #61 per Nick's request — this half is independent of the firmware discussion there and can land on its own.

Some kernels build their in-tree xz-compressed modules with the crc32 integrity check instead of xz's default (crc64), and their module loader only accepts the check type matching the kernel's own scheme. Compressing our out-of-tree modules with the default xz check produces a .ko.xz the kernel's decompressor refuses to unpack on those kernels, making `make install` silently produce modules that never load.

Match the distro's own compression scheme by using --check=crc32.