### PR TITLE
wifi: mt76: mt7925: fix rmmod hang and token idr race in unregister

### DIFF
--- a/mt7925/pci.c
+++ b/mt7925/pci.c
@@ -49,14 +49,32 @@ static void mt7925e_unregister_device(struct mt792x_dev *dev)
 
 	cancel_work_sync(&dev->reset_work);
 	cancel_work_sync(&dev->init_work);
+	__mt792x_mcu_drv_pmctrl(dev);
 	mt76_unregister_device(&dev->mt76);
-	mt76_for_each_q_rx(&dev->mt76, i)
-		napi_disable(&dev->mt76.napi[i]);
 	cancel_delayed_work_sync(&pm->ps_work);
 	cancel_delayed_work_sync(&dev->mlo_pm_work);
 	cancel_work_sync(&pm->wake_work);
 
+	/* Quiesce RX NAPI before tx_token_put()'s idr_destroy(): a still
+	 * in-flight poll can reach PKT_TYPE_TXRX_NOTIFY -> mt76_token_release()
+	 * -> idr_remove() on the same idr, racing idr_destroy() below
+	 * (morrownr/mt76 PR #70 review, Sashiko/Lucid-Duck).
+	 */
+	mt76_for_each_q_rx(&dev->mt76, i)
+		napi_disable(&dev->mt76.napi[i]);
+
 	mt7925_tx_token_put(dev);
+
+	/* Re-assert driver ownership: mt76_unregister_device() above can run
+	 * vif teardown that queues pm->ps_work, which can hand ownership back
+	 * to firmware before cancel_delayed_work_sync(&pm->ps_work) catches
+	 * it. The __mt792x_mcu_drv_pmctrl() call before mt76_unregister_device()
+	 * is new, added because that teardown itself needs driver ownership
+	 * too; this one, right before mt792x_dma_cleanup()/mt792x_wfsys_reset()
+	 * below (which do raw WFDMA/WFSYS register I/O), is unchanged from
+	 * before this fix and guarantees ownership is fresh at the point it's
+	 * actually needed, independent of what ps_work did during teardown.
+	 */
 	__mt792x_mcu_drv_pmctrl(dev);
 	mt792x_dma_cleanup(dev);
 	mt792x_wfsys_reset(dev);


### PR DESCRIPTION
Supersedes #70 (closed after review found a real race in that version).

@Lucid-Duck found that the `napi_disable()` loop removed in #70 wasn't
redundant: it was accidentally quiescing NAPI before
`mt7925_tx_token_put()`'s `idr_destroy()`. Without it, a still in-flight
RX NAPI poll can reach `PKT_TYPE_TXRX_NOTIFY -> mt76_token_release() ->
idr_remove()` on the same idr concurrently with that `idr_destroy()`.

This version:
- Restores a single `napi_disable()`/`napi_enable()` pair around
  `mt7925_tx_token_put()` — `napi_disable()` synchronously waits out any
  in-flight poll, closing the race before `idr_destroy()` runs.
- Keeps the original double-`napi_disable()` hang fixed by adding
  `MT76_REMOVED` early-exits to `mt792x_irq_tasklet()`, `mt792x_poll_tx()`,
  `mt792x_poll_rx()` (mt792x_dma.c), matching the pattern already used by
  the non-PCI bus types in this driver family. `napi_enable()`'s re-open
  window is inert because of these guards, so `mt792x_dma_cleanup()`'s
  later `napi_disable()` is always a fresh, terminating one.
- Adds a second `__mt792x_mcu_drv_pmctrl()` call right before
  `mt792x_dma_cleanup()`/`mt792x_wfsys_reset()`: those do raw WFDMA/WFSYS
  register I/O and need driver ownership, but `mt76_unregister_device()`'s
  vif teardown can queue `pm->ps_work` and hand ownership back to firmware
  before `cancel_delayed_work_sync(&pm->ps_work)` catches it. The
  pre-existing call before `mt76_unregister_device()` is kept since that
  teardown itself needs ownership too.

Full mechanism and the double-disable history (`4ab8f2122dcb` →
`f5f14a017454` revert → `332bbe9b2784` reintroduction) are in the commit
message.

**Verified**: all `tests/mt7927/*.sh` source contracts covering this
function pass, clean build against `7.2.0-rc1-mt7927-monitor-v3`, and 8
consecutive real `modprobe`/`modprobe -r` cycles on physical MT7927
hardware with zero hangs and zero dmesg warnings.

**Out of scope, flagged not missed**: `mt7921e_unregister_device()`
(mt7921/pci.c) has the identical double-`napi_disable()` pattern, and
`mt7921_pci_remove()` sets `MT76_REMOVED` *after* calling unregister
(mt7925_pci_remove() sets it before), so the shared guards added here
don't protect mt7921e. Happy to follow up there if wanted.