### PR TITLE
Revert "wifi: mt76: Disable napi when removing device"

### DIFF
--- a/dma.c
+++ b/dma.c
@@ -1217,10 +1217,7 @@ void mt76_dma_cleanup(struct mt76_dev *dev)
 	mt76_for_each_q_rx(dev, i) {
 		struct mt76_queue *q = &dev->q_rx[i];
 
-		if (!mt76_queue_is_wed_rro(q)) {
-			napi_disable(&dev->napi[i]);
-			netif_napi_del(&dev->napi[i]);
-		}
+		netif_napi_del(&dev->napi[i]);
 		mt76_dma_rx_cleanup(dev, q);
 
 		page_pool_destroy(q->page_pool);


### PR DESCRIPTION
@morrownr This fixes the hang on unload and shutdown for mt7921e and mt7925e.

Since `8be40d4b` the driver turns off receive NAPI twice on the way out. The second one never returns, so `rmmod` sticks, and reboot and poweroff stick with it because they go through the same path. Nothing warns about it, the machine just never finishes going down.

Upstream tried fixing this from the other end and the author pulled it back, and the thread agreed a revert is the way instead. Nothing has been posted for that side yet. The cost is that mt7915 and a couple of others get their old unload warning back until it turns up.

Tested across three kernels. The MT7927 hangs on stock and does ten clean unloads patched. The MT7922 does ten clean patched. An MT7925 stick on USB is clean either way, which is the check that nothing else broke.

https://lore.kernel.org/all/CABXGCsO07SExb+Z0PeN6MZ1fKC24Tvn3ehSyeQc-3qFC7jM7dQ@mail.gmail.com/
