### PR TITLE
wifi: mt76: mt7925: fix remove-time tasklet race

### DIFF
--- a/mt7925/pci.c
+++ b/mt7925/pci.c
@@ -61,8 +61,6 @@ static void mt7925e_unregister_device(struct mt792x_dev *dev)
 	mt792x_dma_cleanup(dev);
 	mt792x_wfsys_reset(dev);
 	skb_queue_purge(&dev->mt76.mcu.res_q);
-
-	tasklet_disable(&dev->mt76.irq_tasklet);
 }
 
 static void mt7925_reg_remap_restore(struct mt792x_dev *dev)
@@ -725,6 +723,7 @@ static void mt7925_pci_remove(struct pci_dev *pdev)
 	set_bit(MT76_REMOVED, &mdev->phy.state);
 	mt7925e_unregister_device(dev);
 	devm_free_irq(&pdev->dev, pdev->irq, dev);
+	tasklet_kill(&dev->mt76.irq_tasklet);
 	mt76_free_device(&dev->mt76);
 	pci_free_irq_vectors(pdev);
 }

--- a/mt792x_dma.c
+++ b/mt792x_dma.c
@@ -31,6 +31,9 @@ void mt792x_irq_tasklet(unsigned long data)
 	const struct mt792x_irq_map *irq_map = dev->irq_map;
 	u32 intr, mask = 0;
 
+	if (test_bit(MT76_REMOVED, &dev->mphy.state))
+		return;
+
 	mt76_wr(dev, irq_map->host_irq_enable, 0);
 
 	intr = mt76_rr(dev, MT_WFDMA0_HOST_INT_STA);
@@ -515,6 +518,11 @@ int mt792x_poll_tx(struct napi_struct *napi, int budget)
 
 	dev = container_of(napi, struct mt792x_dev, mt76.tx_napi);
 
+	if (test_bit(MT76_REMOVED, &dev->mphy.state)) {
+		napi_complete(napi);
+		return 0;
+	}
+
 	if (!mt76_connac_pm_ref(&dev->mphy, &dev->pm)) {
 		napi_complete(napi);
 		queue_work(dev->mt76.wq, &dev->pm.wake_work);
@@ -537,6 +545,11 @@ int mt792x_poll_rx(struct napi_struct *napi, int budget)
 	int done;
 
 	dev = mt76_priv(napi->dev);
+
+	if (test_bit(MT76_REMOVED, &dev->mphy.state)) {
+		napi_complete(napi);
+		return 0;
+	}
 
 	if (!mt76_connac_pm_ref(&dev->mphy, &dev->pm)) {
 		napi_complete(napi);
@@ -620,4 +633,3 @@ int mt792x_wfsys_reset(struct mt792x_dev *dev)
 	return mt792x_wfsys_reset_default(dev);
 }
 EXPORT_SYMBOL_GPL(mt792x_wfsys_reset);
-


### PR DESCRIPTION
This is the post-#72 replacement for the #70/#71 teardown discussion.

#72 removed the shared RX `napi_disable()` from `mt76_dma_cleanup()`, so this patch leaves `mt7925e_unregister_device()`'s existing driver-side RX NAPI quiesce before `mt7925_tx_token_put()` intact and does not re-enable RX NAPI before queue teardown.

Fixes included:

- add `MT76_REMOVED` exits to `mt792x_irq_tasklet()`, `mt792x_poll_tx()`, and `mt792x_poll_rx()`
- remove the unregister-side `tasklet_disable()` from `mt7925e_unregister_device()`
- add `tasklet_kill(&dev->mt76.irq_tasklet)` in `mt7925_pci_remove()` after `devm_free_irq()` and before `mt76_free_device()`

This closes the remaining remove-time tasklet/NAPI lifetime race without carrying the broader #71 pmctrl/NAPI restructuring.

Validation:

- `PR75 source contract: PASS`
- `git diff --check`: PASS
- `checkpatch.pl --strict --no-tree`: 0 errors, 0 warnings
- `make clean && make -j"$(nproc)" KVER="$(uname -r)"`: PASS on `7.2.0-rc1-mt7927-monitor-v3`

References:

- #70
- #71
- #72
- https://lore.kernel.org/all/CABXGCsO07SExb+Z0PeN6MZ1fKC24Tvn3ehSyeQc-3qFC7jM7dQ@mail.gmail.com/
