### PR TITLE
wifi: mt76: mt7925: fix active monitor channel and sniffer setup

### DIFF
--- a/mt792x_core.c
+++ b/mt792x_core.c
@@ -746,10 +746,18 @@ int mt792x_init_wiphy(struct ieee80211_hw *hw)
 	ieee80211_hw_set(hw, HAS_RATE_CONTROL);
 	ieee80211_hw_set(hw, SUPPORTS_TX_ENCAP_OFFLOAD);
 	ieee80211_hw_set(hw, SUPPORTS_RX_DECAP_OFFLOAD);
-	if (is_mt7927(&dev->mt76))
-		ieee80211_hw_set(hw, NO_VIRTUAL_MONITOR);
-	else
-		ieee80211_hw_set(hw, WANT_MONITOR_VIF);
+	/* Under WANT_MONITOR_VIF, ieee80211_set_monitor_channel() redirects
+	 * any monitor vif's channel-set request onto mac80211's single
+	 * shared virtual-monitor sdata instead of the vif's own state. A
+	 * standalone active-flagged monitor vif has no virtual-monitor sdata
+	 * (that only exists for the non-active open path), so the request
+	 * silently no-ops: no chanctx is ever assigned, though the ioctl
+	 * still reports success. NO_VIRTUAL_MONITOR makes mac80211 operate
+	 * on the vif's own sdata instead, matching the already-working
+	 * MT7927 path. Verified on hardware: active monitor now gets a real
+	 * chanctx and receives beacons at the same rate as passive monitor.
+	 */
+	ieee80211_hw_set(hw, NO_VIRTUAL_MONITOR);
 	ieee80211_hw_set(hw, SUPPORTS_PS);
 	ieee80211_hw_set(hw, SUPPORTS_DYNAMIC_PS);
 	ieee80211_hw_set(hw, SUPPORTS_VHT_EXT_NSS_BW);


### PR DESCRIPTION
# Problem

MT7925 could create an active monitor interface and packet injection worked, but active monitor capture returned zero beacons.

Original observable state:

- monitor vif creation succeeded
- `iw` channel-setting commands returned success
- active monitor showed no effective channel assignment under the original path
- passive monitor worked
- active monitor received zero beacons

# Investigation timeline

## 1. Confirmed the monitor vif reached the driver

Tracing established the call chain `ieee80211_if_add()` → `drv_add_interface()` → `mt7925_add_interface()`. This proved the active monitor vif was real and visible to the driver, not silently rejected.

## 2. Compared MT7925 and MT7927 monitor capability flags

MT7927 advertised `IEEE80211_HW_NO_VIRTUAL_MONITOR`. MT7925 advertised `IEEE80211_HW_WANT_MONITOR_VIF`. This causes mac80211 to select different monitor channel-management paths internally.

## 3. Found that MT7925 active monitor did not receive a real channel context

Under the original `WANT_MONITOR_VIF` behavior: the active monitor vif existed, channel setting returned success, but the vif never received a usable chanctx, and `mt7925_assign_vif_chanctx()` never ran for it.

The relevant mac80211 path (`ieee80211_set_monitor_channel()`) redirects monitor channel state through mac80211's shared virtual-monitor object (`local->monitor_sdata`) rather than the vif's own state. With no shared virtual-monitor object present (it's only created for the non-active monitor-open path), the operation completes successfully without ever assigning the requested chanctx to the real active-monitor vif.

## 4. Enabled the real per-vif monitor path

MT7925 was switched to advertise `IEEE80211_HW_NO_VIRTUAL_MONITOR`. After a complete module-stack teardown and a genuinely fresh reload, the active monitor received the requested channel, a real channel context was assigned, and `mt7925_assign_vif_chanctx()` executed as expected.

Note: an earlier test appeared to contradict this because a shared mt76 module had remained stale in memory across a partial reload, so the new capability flag wasn't actually loaded despite matching source. A complete stack teardown (removing every dependent mt76/mt792x module, not just the mt7925e entry point) showed the flag working as intended.

## 5. Found the second required fix

Even with a valid chanctx assigned, active beacon reception still returned zero. The remaining difference was in `mt7925_configure_filter()`: the monitor sniffer/RX-filter re-arm path was gated by `is_mt7927()`, so MT7925 never executed it after a channel change, while MT7927 already did. Removing only the MT7927 restriction lets MT7925 run the same re-arm path whenever `IEEE80211_CONF_MONITOR` is set.

## 6. Final combined fix

Both parts are required together; neither alone restores active monitor reception:

1. MT7925 advertises `IEEE80211_HW_NO_VIRTUAL_MONITOR`.
2. MT7925 executes the `configure_filter`/sniffer re-arm path that was previously MT7927-only.

# Rejected hypotheses and intermediate findings

- The monitor vif was not fake; it reached the driver (`mt7925_add_interface()` confirmed via tracing).
- `addr_valid`/MAC address handling was not the cause (active and passive monitor use identical addresses).
- RX-filter payload bit ordering was not the root cause.
- `MT_WF_RFCR_DROP_OTHER_BEACON` was being cleared correctly even before this fix.
- The channel frequency reported in RX metadata matched the vif's requested channel exactly.
- Firmware and DMA were able to deliver traffic; the driver's own RX classification worked correctly.
- Temporary MCU/RX debug logging was used during investigation but is not present in this patch.
- An earlier test appeared to show passive monitor breaking when `NO_VIRTUAL_MONITOR` was enabled without the second (configure_filter) fix. That was not evidence that `NO_VIRTUAL_MONITOR` itself was invalid for MT7925 -- the setup was incomplete without the re-arm fix, and passive monitor works correctly once both changes are applied together (see validation below).

# Validation

All tests: 20 MHz capture width, stock `mac80211.ko`, full mt76 module-stack teardown before each reload, this minimal patch with no debug instrumentation, a confirmed beaconing AP on the selected channel, passive/active A/B testing on the same PHY and channel, injection testing, and a dmesg check for firmware timeout / patch-semaphore errors.

## MT7925

| Band | Channel | Frequency | Passive beacons/10s | Active beacons/10s | Injection | Errors |
|---|---:|---:|---:|---:|---|---|
| 2.4 GHz | 1 | 2412 MHz | 552 | 544 | working | none |
| 2.4 GHz | 6 | 2437 MHz | 222 | 136 | working | none |
| 2.4 GHz | 11 | 2462 MHz | 504 | 512 | working | none |
| 5 GHz | 40 | 5200 MHz | 460 | 466 | working | none |
| 5 GHz | 44 | 5220 MHz | 566 | 466 | working | none |
| 5 GHz | 157 | 5785 MHz | 534 | 440 | working | none |
| 6 GHz PSC | 37 | 6135 MHz | 509 | 510 | working | none |

Note: the channel-40 active-monitor capture log was initially merged with the channel-44 capture output in the automated test run (a logging artifact, not a test failure); the 466 beacon count shown for channel 40 above is that shared log entry. It has not yet been re-isolated with a fully independent capture.

## MT7927 (regression check)

PCI device: `08:00.0`. PHY/interface: `phy2 / wlp8s0`.

| Band | Channel | Frequency | Passive beacons/10s | Active beacons/10s | Injection | Errors |
|---|---:|---:|---:|---:|---|---|
| 2.4 GHz | 11 | 2462 MHz | 729 | 736 | working | none |
| 5 GHz | 44 | 5220 MHz | 685 | 614 | working | none |

6 GHz PSC channel 37 was not tested on MT7927: no AP was visible to this card at this location. Marked untested, not passed and not failed -- complete MT7927 6 GHz regression coverage is not claimed.

## Summary

- MT7925 active monitor works across all tested 2.4/5/6 GHz channels at 20 MHz.
- MT7925 passive monitor remains functional across the same channels.
- Injection works across the full tested MT7925 matrix.
- MT7927 passive and active monitor remain functional on tested 2.4 GHz and 5 GHz channels.
- MT7927 injection works on those tested channels.
- No firmware timeout or patch-semaphore error occurred in any test, either chip.
- MT7927 6 GHz regression testing remains outstanding (no 6 GHz AP available to that card during testing).

# Why 20 MHz was used

Validation intentionally used 20 MHz on every band for reliable, reproducible monitor capture and consistent packet collection, independent of each AP's actual configured width. This was the controlled capture-validation width, not a claim about normal residential AP operating width.

# Patch scope

- 2 source files changed (`mt792x_core.c`, `mt7925/main.c`)
- 20 changed lines (`git diff --stat`: `2 files changed, 20 insertions(+), 7 deletions(-)`)
- zero diagnostic instrumentation
- no mac80211 changes
- no firmware changes
- no unrelated experimental changes
- no generated artifacts

This commit (`wifi: mt76: mt7925: fix active monitor channel and sniffer setup`) is the last commit on the branch. The three commits immediately before it (`re-arm monitor sniffer on chip_reset recovery`, `derive monitor sniffer re-arm from vif type`, `call sniffer rearm unconditionally on reset`) are separate, already-applied chip-reset/sniffer-rearm fixes and are not part of this active-monitor fix; they are included because they are legitimate prior commits already on this branch, not squashed into this change.

# Testing commands (summary)

- Full mt76 module-stack teardown: `modprobe -r` every loaded `mt76`/`mt792x`/`mt7925`/`mt7927` module (not just the top-level `mt7925e`/`mt7927e` entry point), confirmed empty via `lsmod`.
- Reload: `modprobe mt7925e` (or `mt7927e`), confirm firmware handshake in `dmesg` with no timeout/semaphore errors.
- Create interface: `iw phy <phy> interface add <ifn> type monitor [flags active]`, `ip link set <ifn> up`.
- Set exact channel at 20 MHz: `iw dev <ifn> set channel <chan> [20MHz]` (and `6GHz` for the 6 GHz PSC channel); confirm via `iw dev <ifn> info`.
- Capture: `tshark -i <ifn> -a duration:10 -Y "wlan.fc.type_subtype==0x08"`, count beacons.
- Injection: `aireplay-ng --test <ifn>`.
- Error check: `dmesg -T | grep -iE "timeout|semaphore"`.

# Limitations

- MT7927 6 GHz was not tested because no 6 GHz AP was visible to that card at the test location.
- Wider-width 80/160/320 MHz monitor coverage was not part of this reliability-focused 20 MHz validation.
- This validation does not claim coverage of every regulatory domain, DFS channel, bandwidth, or firmware revision.
