### PR TITLE
MAINTAINING.md: document deliberate differences from upstream

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -71,6 +71,14 @@ Short commit id or long, git takes any unique piece of it. Use the 12-character 
 
 When a cherry-pick doesn't apply cleanly, it's almost always one of two shapes. Either openwrt changed a function we've wrapped in a compat guard, in which case keep their change and put the guard back around the new version. Or openwrt touched code we'd already patched a different way, which is rarer, and you look at both and decide what to keep.
 
+## Deliberate differences from upstream
+
+Two spots in the tree are intentionally not what openwrt/mt76 (or Felix's tree) does. Both were changed on purpose, for a reason written down in the commit, and neither should get silently overwritten by a future cherry-pick.
+
+**RX NAPI is disabled once, not twice, on device removal.** mt7921e_unregister_device() and mt7925e_unregister_device() already disable every RX NAPI instance before mt76_dma_cleanup() runs. Upstream commit 8be40d4b194c ("wifi: mt76: Disable napi when removing device") added a second napi_disable() inside mt76_dma_cleanup() itself, and a second call with no napi_enable() in between hangs forever, because napi_disable() leaves NAPI_STATE_SCHED set until something clears it. We reverted that commit (#72). If a future cherry-pick from openwrt touches mt76_dma_cleanup() or either driver's unregister path, check whether it's reintroducing that same double-disable before taking it. mt7915 and any other driver that never disabled RX NAPI on its own before deleting it will regain the unload warnings 8be40d4b194c was written to fix, until mt7915 gets its own local napi_disable() the way mt7921e/mt7925e already have one.
+
+**mt7925 sets NO_VIRTUAL_MONITOR, not WANT_MONITOR_VIF.** Upstream asks mac80211 for a virtual monitor vif on every mt792x chip. Felix's tree splits it by chip. We now skip the virtual monitor on all of them (#76). The reason: mac80211's ieee80211_set_monitor_channel() only assigns a real per-vif channel context to a monitor vif when NO_VIRTUAL_MONITOR is set; under WANT_MONITOR_VIF, an explicitly-created active monitor vif has no virtual-monitor state to attach to, so channel setup silently no-ops and active monitor never receives a chanctx or any beacons. NO_VIRTUAL_MONITOR fixes that; testing found no passive-monitor regression on mt7921 (USB and PCIe), mt7925 (USB), or MT7927 (all three bands). If a future cherry-pick touches the hw_set() calls in mt792x_core.c's init_wiphy and tries to reintroduce WANT_MONITOR_VIF or a per-chip split, keep NO_VIRTUAL_MONITOR unconditional unless upstream has separately fixed the underlying mac80211 gap for active monitor vifs.
+
 ## Keeping it building on old kernels
 
 The tree has to build all the way down to kernel 6.12, because that's what current Debian ships and plenty of people are on it. When the kernel changes the shape of something between 6.12 and now, we guard it right in the code:


### PR DESCRIPTION
Per Lucid-Duck's note in #32: two spots in the tree are intentionally not what openwrt/mt76 or Felix's tree does -- the reverted double napi_disable() (#72) and mt7925's unconditional NO_VIRTUAL_MONITOR (#76). Neither was written down anywhere. This adds a short section to MAINTAINING.md next to the cherry-pick guidance, explaining each one and what to check if a future cherry-pick touches that area.

Documentation only, no driver code changed.