### PR TITLE
add show-picks.sh and a skip list for commits we are not taking

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -71,6 +71,20 @@ Short commit id or long, git takes any unique piece of it. Use the 12-character 
 
 When a cherry-pick doesn't apply cleanly, it's almost always one of two shapes. Either openwrt changed a function we've wrapped in a compat guard, in which case keep their change and put the guard back around the new version. Or openwrt touched code we'd already patched a different way, which is rarer, and you look at both and decide what to keep.
 
+## Seeing what is left to pick
+
+    ./show-picks.sh
+
+Lists what openwrt/mt76 has that we do not, oldest first. It works out what is already here by
+reading the "cherry picked from commit" lines, which is why the -x above matters.
+
+For a commit we have decided not to take, put its id in picks-skip.txt with a reason:
+
+    2dd6e4c8  # MT7981 firmware, SoC part this tree does not ship
+
+It drops off the list and gets counted at the bottom instead, so the reason survives and nobody
+re-examines it in six months.
+
 ## Keeping it building on old kernels
 
 The tree has to build all the way down to kernel 6.12, because that's what current Debian ships and plenty of people are on it. When the kernel changes the shape of something between 6.12 and now, we guard it right in the code:

--- a/picks-skip.txt
+++ b/picks-skip.txt
@@ -1,0 +1,5 @@
+# Commits in openwrt/mt76 we have decided not to take.
+# One id per line, reason after a #. Short or long id both work.
+
+2dd6e4c8  # MT7981 firmware, SoC part this tree does not ship
+50a0c305  # MT7986 firmware, same

--- a/show-picks.sh
+++ b/show-picks.sh
@@ -1,0 +1,93 @@
+#!/bin/sh
+# show-picks.sh - list openwrt/mt76 commits not yet cherry-picked into this tree.
+#
+# Run it from your morrownr/mt76 clone. It needs a git remote named "openwrt"
+# pointing at the openwrt mt76 repo. If you do not have one yet:
+#
+#     git remote add openwrt https://github.com/openwrt/mt76.git
+#
+# It reads the "(cherry picked from commit ...)" lines that git cherry-pick -x
+# adds, so keep using -x and this stays accurate.
+#
+# To drop a commit you have decided not to take, put its id in picks-skip.txt
+# beside this script, one per line, reason after a #:
+#
+#     a1b2c3d4e5f6  # mt7981 firmware, not a chip we ship
+#
+# Short or long id, either works. Skipped commits stop showing up in the list.
+
+set -u
+
+REMOTE=openwrt
+BRANCH=master
+
+if ! git rev-parse --git-dir >/dev/null 2>&1; then
+    echo "Not inside a git repository. cd into your morrownr/mt76 clone first."
+    exit 1
+fi
+
+if ! git remote | grep -qx "$REMOTE"; then
+    echo "No '$REMOTE' remote found. Add it once with:"
+    echo
+    echo "    git remote add $REMOTE https://github.com/openwrt/mt76.git"
+    echo
+    exit 1
+fi
+
+skipfile=$(dirname "$0")/picks-skip.txt
+skiplist=""
+if [ -f "$skipfile" ]; then
+    skiplist=$(sed 's/#.*//' "$skipfile" | tr -d ' \t' | grep -v '^$')
+fi
+
+# true when $1, a full commit id, starts with any id listed in picks-skip.txt
+is_skipped() {
+    _full=$1
+    _oldifs=$IFS
+    IFS='
+'
+    for _id in $skiplist; do
+        case "$_full" in
+        "$_id"*)
+            IFS=$_oldifs
+            return 0
+            ;;
+        esac
+    done
+    IFS=$_oldifs
+    return 1
+}
+
+echo "Fetching $REMOTE ..."
+if ! git fetch -q "$REMOTE"; then
+    echo "Could not fetch $REMOTE. Check your connection and the remote URL."
+    exit 1
+fi
+
+applied=$(git log --grep='cherry picked from commit' \
+    | sed -n 's/.*cherry picked from commit \([0-9a-f]\{7,\}\).*/\1/p')
+
+echo
+echo "Commits in $REMOTE/$BRANCH not yet picked here (oldest first):"
+echo
+
+git log --reverse --no-merges --format='%H %h %s' "HEAD..$REMOTE/$BRANCH" \
+    | while read -r full short subject; do
+        case "$applied" in
+        *"$full"*)
+            continue
+            ;;
+        esac
+        if is_skipped "$full"; then
+            continue
+        fi
+        printf '  %s  %s\n' "$short" "$subject"
+    done
+
+echo
+if [ -n "$skiplist" ]; then
+    printf 'Skipping %s commit(s) listed in %s.\n\n' \
+        "$(printf '%s\n' "$skiplist" | grep -c .)" "$(basename "$skipfile")"
+fi
+echo "Nothing listed means you are caught up. Pick the rest oldest first,"
+echo "and keep using 'git cherry-pick -x' so they stay tracked."


### PR DESCRIPTION
@morrownr asked how to take a line item off the show-picks.sh list. There was no way to do it, so this adds one.

The script only ever worked out what was already picked by reading the "cherry picked from commit" lines in our log, so an entry stayed on the list until something in the tree referenced that hash. It now also reads picks-skip.txt beside it:

    2dd6e4c8  # MT7981 firmware, SoC part this tree does not ship

Those drop off the list and get counted at the bottom instead, so a decision not to take something is recorded once rather than re-made every time someone reads the output. Short and long commit ids both work.

Seeded with the MT7981 and MT7986 firmware updates. I left the MT7996 firmware alone since we do take mt7996 fixes.

The script itself has been living in Nick's inbox since June, so it is in the tree now, next to the cherry-picking it is about. MAINTAINING.md gets a short section pointing at both.

Tested against a clone of this repo: 20 commits outstanding from openwrt before the skip file, 18 after, with the two counted at the bottom. shellcheck clean and parses under dash.