### PR TITLE
wifi: mt76: mt7925: disable firmware-level frame drop in monitor mode

### DIFF
--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -923,11 +923,11 @@ static void mt7925_configure_filter(struct ieee80211_hw *hw,
 				    unsigned int *total_flags,
 				    u64 multicast)
 {
-#define MT7925_FILTER_FCSFAIL    BIT(2)
 #define MT7925_FILTER_CONTROL    BIT(5)
 #define MT7925_FILTER_OTHER_BSS  BIT(6)
 #define MT7925_FILTER_ENABLE     BIT(31)
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
+	struct mt792x_phy *phy = mt792x_hw_phy(hw);
 	u32 flags = MT7925_FILTER_ENABLE;
 
 #define MT7925_FILTER(_fif, _type) do {			\
@@ -938,6 +938,12 @@ static void mt7925_configure_filter(struct ieee80211_hw *hw,
 	MT7925_FILTER(FIF_FCSFAIL, FCSFAIL);
 	MT7925_FILTER(FIF_CONTROL, CONTROL);
 	MT7925_FILTER(FIF_OTHER_BSS, OTHER_BSS);
+
+	/* Persist what mac80211 actually asked for so the firmware sniffer
+	 * config (mt7925_mcu_config_sniffer()) can honour it instead of
+	 * hardcoding drop_err.
+	 */
+	phy->rxfilter = flags;
 
 	mt792x_mutex_acquire(dev);
 	mt7925_mcu_set_rxfilter(dev, flags, 0, 0);

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -923,7 +923,6 @@ static void mt7925_configure_filter(struct ieee80211_hw *hw,
 				    unsigned int *total_flags,
 				    u64 multicast)
 {
-#define MT7925_FILTER_FCSFAIL    BIT(2)
 #define MT7925_FILTER_CONTROL    BIT(5)
 #define MT7925_FILTER_OTHER_BSS  BIT(6)
 #define MT7925_FILTER_ENABLE     BIT(31)
@@ -938,6 +937,12 @@ static void mt7925_configure_filter(struct ieee80211_hw *hw,
 	MT7925_FILTER(FIF_FCSFAIL, FCSFAIL);
 	MT7925_FILTER(FIF_CONTROL, CONTROL);
 	MT7925_FILTER(FIF_OTHER_BSS, OTHER_BSS);
+
+	/* Persist what mac80211 actually asked for so the firmware sniffer
+	 * config (mt7925_mcu_config_sniffer()) can honour it instead of
+	 * hardcoding drop_err.
+	 */
+	dev->mt76.rxfilter = flags;
 
 	mt792x_mutex_acquire(dev);
 	mt7925_mcu_set_rxfilter(dev, flags, 0, 0);

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -2333,7 +2333,13 @@ int mt7925_mcu_config_sniffer(struct mt792x_vif *vif,
 			.len = cpu_to_le16(sizeof(req.tlv)),
 			.control_ch = chandef->chan->hw_value,
 			.center_ch = ieee80211_frequency_to_channel(freq1),
-			.drop_err = 0,
+			/* Only pass unfiltered/marginal frames when the
+			 * monitor userspace actually asked for them
+			 * (FIF_FCSFAIL, persisted by mt7925_configure_filter()).
+			 * Otherwise keep firmware's default drop behaviour.
+			 */
+			.drop_err = !(vif->phy->rxfilter &
+				      MT7925_FILTER_FCSFAIL),
 		},
 	};
 

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -2333,7 +2333,13 @@ int mt7925_mcu_config_sniffer(struct mt792x_vif *vif,
 			.len = cpu_to_le16(sizeof(req.tlv)),
 			.control_ch = chandef->chan->hw_value,
 			.center_ch = ieee80211_frequency_to_channel(freq1),
-			.drop_err = 0,
+			/* Only pass unfiltered/marginal frames when the
+			 * monitor userspace actually asked for them
+			 * (FIF_FCSFAIL, persisted by mt7925_configure_filter()).
+			 * Otherwise keep firmware's default drop behaviour.
+			 */
+			.drop_err = !(vif->phy->dev->mt76.rxfilter &
+				      MT7925_FILTER_FCSFAIL),
 		},
 	};
 

--- a/mt7925/mcu.c
+++ b/mt7925/mcu.c
@@ -2333,7 +2333,7 @@ int mt7925_mcu_config_sniffer(struct mt792x_vif *vif,
 			.len = cpu_to_le16(sizeof(req.tlv)),
 			.control_ch = chandef->chan->hw_value,
 			.center_ch = ieee80211_frequency_to_channel(freq1),
-			.drop_err = 1,
+			.drop_err = 0,
 		},
 	};
 

--- a/mt7925/mt7925.h
+++ b/mt7925/mt7925.h
@@ -9,6 +9,12 @@
 
 #define MT7925_BEACON_RATES_TBL		25
 
+/* Bit mac80211's FIF_FCSFAIL request is mirrored into, persisted on
+ * dev->mt76.rxfilter by mt7925_configure_filter() so mt7925_mcu_config_sniffer()
+ * can honour it later instead of hardcoding the firmware sniffer's drop_err.
+ */
+#define MT7925_FILTER_FCSFAIL		BIT(2)
+
 #define MT7925_TX_RING_SIZE		2048
 #define MT7925_TX_MCU_RING_SIZE		256
 #define MT7925_TX_FWDL_RING_SIZE	128

--- a/mt792x.h
+++ b/mt792x.h
@@ -175,6 +175,8 @@ struct mt792x_phy {
 	s16 coverage_class;
 	u8 slottime;
 
+	u32 rxfilter;
+
 	u32 rx_ampdu_ts;
 	u32 ampdu_ref;
 


### PR DESCRIPTION
## Summary

`mt7925_mcu_sniffer_interface_update()` (mt7925/mcu.c) sets `drop_err = 1`
unconditionally in the `UNI_SNIFFER_CONFIG` MCU command. This tells the
firmware to filter weak/marginal management frames before they reach
mac80211's monitor interface, which defeats the point of monitor mode
for passive capture / auditing use cases.

Follow-up to #18. Original report there leaned on kernel-level
capture/drop counters, which turned out not to move either way — see
the controlled A/B below for the metric that actually shows the effect.

## Testing

Same MT7925 hardware, same AP environment, everything else held still.
Two runs per side, `hcxdumptool -i wlp7s0 --rcascan=active --rds=5 -F`
(full 140-channel sweep across 2.4/5/6GHz), each run to completion.

| Run | drop_err | Packets captured | Dropped by kernel | APs discovered |
|---|---|---|---|---|
| Stock 1 | 1 | 50574 | 0 | 59 |
| Stock 2 | 1 | 36099 | 0 | 60 |
| Patched 1 | 0 | 41512 | 0 | 319 |
| Patched 2 | 0 | 41162 | 0 | 348 |

Kernel capture/drop counters: no difference either way (0 both sides,
every run). Raw packet count: stock captured more, not fewer — not the
effect I originally expected.

AP discovery: stock consistently ~59-60, patched consistently
~319-348, repeatable across two runs each. ~5.5x increase, and it's
the metric that's actually sensitive to this flag — `drop_err=0` lets
through weak/marginal beacons and probe responses that stock firmware
filters out, and they get parsed as distinct APs.

CC @Lucid-Duck
