### PR TITLE
wifi: mt76: mt7921: check drv_pmctrl return in the PCIe reset path

### DIFF
--- a/mt7921/pci_mac.c
+++ b/mt7921/pci_mac.c
@@ -57,7 +57,9 @@ int mt7921e_mac_reset(struct mt792x_dev *dev)
 {
 	int i, err;
 
-	mt792xe_mcu_drv_pmctrl(dev);
+	err = mt792xe_mcu_drv_pmctrl(dev);
+	if (err)
+		return err;
 
 	mt76_connac_free_pending_tx_skbs(&dev->pm, NULL);
 

--- a/skip-picks.txt
+++ b/skip-picks.txt
@@ -10,3 +10,10 @@ f6cf5faf  # firmware: update MT7996 firmware to version 20260311
 #
 # Keep these lines commented. They are our own commits rather than openwrt
 # ones, so a bare id here would be counted as a skip and throw the tally off.
+
+# mt7921: check drv_pmctrl return in the PCIe reset path
+#   Merged 2026-08-26. Without it a failed driver-own handshake still lets the
+#   reset write registers and reload firmware onto a chip we do not own.
+#   Reported and tested by moosager on their own hardware. On the list since
+#   2026-08-09:
+#   https://lore.kernel.org/linux-wireless/20260809012309.43657-1-lucid_duck@justthetip.ca/


### PR DESCRIPTION
One of mine. On linux-wireless since the ninth, and tested by the person who reported it since the twentieth:

https://lore.kernel.org/linux-wireless/20260809012309.43657-1-lucid_duck@justthetip.ca/

mt7921e_mac_reset() throws away what the driver-own handshake returns. Every other caller checks it. When the handshake fails the reset carries on anyway, writing interrupt registers, cycling NAPI and downloading firmware onto a chip the driver does not own.

Held the ownership register asserted on an MT7922 here and triggered a reset. Stock gave eight ownership failures, each followed by an MCU timeout and a failed firmware download. With the return checked, twenty six failures produced no download at all, and the reset finally logged that it had failed, which it never managed before.

Second commit is the skip-picks entry.

Rebase merge rather than squash, so the two stay separate.