### PR TITLE
Three fixes Felix has taken upstream that this tree does not carry

### DIFF
--- a/mt7921/main.c
+++ b/mt7921/main.c
@@ -656,9 +656,9 @@ static int mt7921_config(struct ieee80211_hw *hw, u32 changed)
 	}
 
 	if (changed & IEEE80211_CONF_CHANGE_MONITOR) {
-		ieee80211_iterate_active_interfaces(hw,
-						    IEEE80211_IFACE_ITER_RESUME_ALL,
-						    mt7921_sniffer_interface_iter, dev);
+		ieee80211_iterate_active_interfaces_mtx(hw,
+							IEEE80211_IFACE_ITER_RESUME_ALL,
+							mt7921_sniffer_interface_iter, dev);
 	}
 
 out:

--- a/mt7925/main.c
+++ b/mt7925/main.c
@@ -907,9 +907,9 @@ static int mt7925_config(struct ieee80211_hw *hw, u32 changed)
 	}
 
 	if (changed & IEEE80211_CONF_CHANGE_MONITOR) {
-		ieee80211_iterate_active_interfaces(hw,
-						    IEEE80211_IFACE_ITER_RESUME_ALL,
-						    mt7925_sniffer_interface_iter, dev);
+		ieee80211_iterate_active_interfaces_mtx(hw,
+							IEEE80211_IFACE_ITER_RESUME_ALL,
+							mt7925_sniffer_interface_iter, dev);
 	}
 
 out:

--- a/mt7925/pci_mac.c
+++ b/mt7925/pci_mac.c
@@ -73,7 +73,9 @@ int mt7925e_mac_reset(struct mt792x_dev *dev)
 	const struct mt792x_irq_map *irq_map = dev->irq_map;
 	int i, err;
 
-	mt792xe_mcu_drv_pmctrl(dev);
+	err = mt792xe_mcu_drv_pmctrl(dev);
+	if (err)
+		return err;
 
 	mt76_connac_free_pending_tx_skbs(&dev->pm, NULL);
 

--- a/skip-picks.txt
+++ b/skip-picks.txt
@@ -21,6 +21,21 @@ f6cf5faf  # firmware: update MT7996 firmware to version 20260311
 # and show-picks offers it as something we are missing. At that point it wants
 # a line in section 1, with the reason being that we already carry it.
 
+# mt7921: fix lock inversion between dev->mutex and iflist_mtx
+#   Merged 2026-08-28. Accepted upstream, waiting in Felix's mt76-fixes.
+#   On the list since 2026-08-10.
+#   https://lore.kernel.org/linux-wireless/20260810045338.118923-2-lucid_duck@justthetip.ca/
+
+# mt7925: fix lock inversion between dev->mutex and iflist_mtx
+#   Merged 2026-08-28. Accepted upstream, waiting in Felix's mt76-fixes.
+#   On the list since 2026-08-10.
+#   https://lore.kernel.org/linux-wireless/20260810045338.118923-3-lucid_duck@justthetip.ca/
+
+# mt7925: check drv_pmctrl return in the PCIe reset path
+#   Merged 2026-08-28. Accepted upstream, waiting in Felix's mt76-fixes.
+#   On the list since 2026-08-09.
+#   https://lore.kernel.org/linux-wireless/20260809205559.32116-1-lucid_duck@justthetip.ca/
+
 # mt7921: check drv_pmctrl return in the PCIe reset path
 #   Merged 2026-08-26. Reported and tested by moosager on their own
 #   hardware. On the list since 2026-08-09.


### PR DESCRIPTION
All three are accepted and waiting in Felix's mt76-fixes branch. They are not in a released kernel yet, so merging here puts them in front of users before the in-kernel driver has them.

Two of them are the same lock inversion, in mt7921 and mt7925. config holds the device mutex while walking the interface list, and that walk takes a lock mac80211 holds in the other order when a monitor interface with a channel is deleted. Reproduced here with lockdep on an MT7922.

The third stops mt7925's PCIe reset from carrying on when the driver fails to take ownership of the chip. Today it writes registers and downloads firmware anyway.

Nine lines added, seven removed. Builds clean on 7.1.10 and 7.2-rc4, every module, no errors. Recorded in skip-picks section 3, and the tally is unchanged.