### PR TITLE
The other half of the FCS-fail fix, for mt7921

### DIFF
--- a/mt7921/main.c
+++ b/mt7921/main.c
@@ -672,12 +672,8 @@ static void mt7921_configure_filter(struct ieee80211_hw *hw,
 				    unsigned int *total_flags,
 				    u64 multicast)
 {
-#define MT7921_FILTER_FCSFAIL    BIT(2)
-#define MT7921_FILTER_CONTROL    BIT(5)
-#define MT7921_FILTER_OTHER_BSS  BIT(6)
-#define MT7921_FILTER_ENABLE     BIT(31)
-
 	struct mt792x_dev *dev = mt792x_hw_dev(hw);
+	struct mt792x_phy *phy = mt792x_hw_phy(hw);
 	u32 flags = MT7921_FILTER_ENABLE;
 
 #define MT7921_FILTER(_fif, _type) do {			\
@@ -688,6 +684,8 @@ static void mt7921_configure_filter(struct ieee80211_hw *hw,
 	MT7921_FILTER(FIF_FCSFAIL, FCSFAIL);
 	MT7921_FILTER(FIF_CONTROL, CONTROL);
 	MT7921_FILTER(FIF_OTHER_BSS, OTHER_BSS);
+
+	phy->rxfilter = flags;
 
 	mt792x_mutex_acquire(dev);
 	mt7921_mcu_set_rxfilter(dev, flags, 0, 0);

--- a/mt7921/mcu.c
+++ b/mt7921/mcu.c
@@ -1228,7 +1228,7 @@ int mt7921_mcu_config_sniffer(struct mt792x_vif *vif,
 			.len = cpu_to_le16(sizeof(req.tlv)),
 			.control_ch = chandef->chan->hw_value,
 			.center_ch = ieee80211_frequency_to_channel(freq1),
-			.drop_err = 1,
+			.drop_err = !(vif->phy->rxfilter & MT7921_FILTER_FCSFAIL),
 		},
 	};
 	if (chandef->chan->band < ARRAY_SIZE(ch_band))

--- a/mt7921/mt7921.h
+++ b/mt7921/mt7921.h
@@ -7,6 +7,11 @@
 #include "../mt792x.h"
 #include "regs.h"
 
+#define MT7921_FILTER_FCSFAIL		BIT(2)
+#define MT7921_FILTER_CONTROL		BIT(5)
+#define MT7921_FILTER_OTHER_BSS		BIT(6)
+#define MT7921_FILTER_ENABLE		BIT(31)
+
 #define MT7921_MAX_AID                  20
 
 #define MT7921_TX_RING_SIZE		2048

--- a/skip-picks.txt
+++ b/skip-picks.txt
@@ -50,6 +50,6 @@ f6cf5faf  # firmware: update MT7996 firmware to version 20260311
 #   https://lore.kernel.org/linux-wireless/20260826092755.480190-1-markanthonyagarro@gmail.com/
 
 # mt7921: honour FIF_FCSFAIL instead of hardcoding drop_err
-#   Merged 2026-09-05. Accepted upstream, waiting in Felix's mt76-fixes.
+#   Merged 2026-09-06. Accepted upstream, waiting in Felix's mt76-fixes.
 #   On the list since 2026-08-26.
 #   https://lore.kernel.org/linux-wireless/20260826231029.39632-1-lucid_duck@justthetip.ca/

--- a/skip-picks.txt
+++ b/skip-picks.txt
@@ -48,3 +48,8 @@ f6cf5faf  # firmware: update MT7996 firmware to version 20260311
 # mt76x02: validate TX-status rate index before mac80211 handoff
 #   Merged 2026-08-26. On the list since 2026-08-26.
 #   https://lore.kernel.org/linux-wireless/20260826092755.480190-1-markanthonyagarro@gmail.com/
+
+# mt7921: honour FIF_FCSFAIL instead of hardcoding drop_err
+#   Merged 2026-09-05. Accepted upstream, waiting in Felix's mt76-fixes.
+#   On the list since 2026-08-26.
+#   https://lore.kernel.org/linux-wireless/20260826231029.39632-1-lucid_duck@justthetip.ca/


### PR DESCRIPTION
Accepted upstream, still waiting in Felix's mt76-fixes. Merging here puts it in front of users before a released kernel has it.

This tree already carries the mt7925 half. This is mt7921, and the field it needs is already here.

A monitor asks to see frames that failed their checksum. The driver works the answer out, sends it to the firmware, then throws it away and tells the sniffer to drop them anyway. At the edge of range that is most of what arrives.

Measured on an MT7922 here, reading the byte as the driver sends it:

```
                  drop_err            stored filter
request       stock    patched     stock       patched
none          1 1 1    1 1 1       0x00000000  0x80000040
fcsfail       1 1 1    0 0 0       0x00000000  0x80000044
none again    1 1 1    1 1 1       0x00000000  0x80000040
                                   channels 1, 6 and 11
```

Withdrawing the request puts the byte back. Nothing sticks. Stock computes the filter correctly and does not keep it.

Built unpatched and patched against each of these:

```
6.18.37-lts
7.0.5
7.1.0-rc4
7.1.10
7.2-rc4
7.2.0-rc5
```

Nine lines added, six removed. Every module, no errors, and the build log is identical to the unpatched tree. Only the four mt7921 modules change. Recorded in skip-picks section 3, tally unchanged.
