### PR TITLE
Build with clang when the kernel was built with clang

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -104,6 +104,16 @@ else
 
 KVER ?= $(shell uname -r)
 KDIR ?= /lib/modules/$(KVER)/build
+
+# A kernel built with clang records that in its config, and kbuild then
+# emits clang-only flags for every module built against it, whichever
+# compiler is doing the building. So a clang kernel needs a clang module
+# build. Detect it here so make, install-driver.sh and dkms all get it
+# without the user having to know. Override with LLVM= on the command line.
+ifeq ($(shell grep -qs '^CONFIG_CC_IS_CLANG=y' $(KDIR)/.config && echo y),y)
+LLVM ?= 1
+export LLVM
+endif
 MODDIR ?= /lib/modules/$(KVER)/extra/mt76
 FWDIR := /lib/firmware/mediatek
 NPROC ?= $(shell nproc --ignore=1)

--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ The installer checks for all of these automatically:
 - Kernel header files for your running kernel
 - Optional: `dkms` for automatic rebuilds on kernel updates
 
+**Kernels built with clang** (CachyOS, Chimera) need
+their modules built with clang too. The Makefile detects this from the kernel's
+config and switches to `LLVM=1` on its own, for `make`, `install-driver.sh` and
+dkms alike. Install `clang`, `lld` and `llvm` first; the package names are the
+same on Arch, Debian and Fedora. The tell that you are on such a kernel and the
+tools are missing is gcc failing with `unrecognized command-line option
+'-mstack-alignment=8'`.
+
 ## Reporting Issues
 
 Run `check-driver.sh` and include the full output in your bug report:

--- a/install-driver.sh
+++ b/install-driver.sh
@@ -152,6 +152,15 @@ fi
 
 printf "  Kernel:  %s (%s)\n" "${KVER}" "${KARCH}"
 
+# the compiler the kernel was built with decides which compiler can build
+# modules for it (see the clang note in the prerequisite check below)
+KCONFIG="/lib/modules/${KVER}/build/.config"
+KERNEL_CC=""
+if [ -f "${KCONFIG}" ]; then
+	KERNEL_CC=$(sed -n 's/^CONFIG_CC_VERSION_TEXT="\(.*\)"$/\1/p' "${KCONFIG}")
+	[ -n "${KERNEL_CC}" ] && printf "  Built:   %s\n" "${KERNEL_CC}"
+fi
+
 # kernel parameters
 if [ -f /proc/cmdline ]; then
 	KPARAMS=$(sed 's/root=[^ ]*//;s/[ ]\+/, /g;s/^BOOT_IMAGE=[^ ]*//' /proc/cmdline | sed 's/^, //')
@@ -286,6 +295,26 @@ if ! command -v bc >/dev/null 2>&1; then
 fi
 if ! command -v make >/dev/null 2>&1; then
 	MISSING="${MISSING} make"
+fi
+
+# A kernel built with clang (CachyOS, Chimera) makes
+# kbuild pass clang-only flags to whatever compiler builds a module, so gcc
+# fails on it with "unrecognized command-line option -mstack-alignment=8".
+# The Makefile switches the build to clang on its own; it just needs the
+# tools installed. Package names are the same on Arch, Debian and Fedora.
+if [ -f "${KCONFIG}" ] && grep -q '^CONFIG_CC_IS_CLANG=y' "${KCONFIG}"; then
+	for tool in clang ld.lld llvm-ar; do
+		if ! command -v "${tool}" >/dev/null 2>&1; then
+			case "${tool}" in
+				clang)   MISSING="${MISSING} clang" ;;
+				ld.lld)  MISSING="${MISSING} lld" ;;
+				llvm-ar) MISSING="${MISSING} llvm" ;;
+			esac
+		fi
+	done
+	if [ -n "${MISSING}" ]; then
+		printf '  This kernel was built with clang, so its modules must be too.\n'
+	fi
 fi
 
 if [ -n "${MISSING}" ]; then


### PR DESCRIPTION
A kernel built with clang records that in its config, and kbuild then hands
clang-only flags to whichever compiler builds a module against it. gcc rejects
them and the build dies with `unrecognized command-line option
'-mstack-alignment=8'`, which is #100.

The Makefile now reads that config and switches to clang on its own, so
`make`, `install-driver.sh` and dkms all get it. The install script names the
three tools a clang kernel needs when they are missing. dkms 3.2 and later
already pass `LLVM=1` themselves; the non-dkms path and older dkms did not.

Measured on the reporter's kernel, CachyOS `7.2.3-1-cachyos`, clang 22.1.8:

	                                    before          after
	make                                24 errors, 0    26 modules
	install-driver.sh, no dkms          fails as #100   26 modules
	install-driver.sh, dkms 3.4.3       26 modules      26 modules
	clang missing                       fails as #100   names clang, lld, llvm

On a gcc kernel, 6.18.37, the detection stays quiet and gcc builds all 26.

Closes #100
