### PR TITLE
wifi: mt76: fix memory leak in USB TX path

### DIFF
--- a/skip-picks.txt
+++ b/skip-picks.txt
@@ -53,3 +53,10 @@ f6cf5faf  # firmware: update MT7996 firmware to version 20260311
 #   Merged 2026-09-06. Accepted upstream, waiting in Felix's mt76-fixes.
 #   On the list since 2026-08-26.
 #   https://lore.kernel.org/linux-wireless/20260826231029.39632-1-lucid_duck@justthetip.ca/
+
+# mt792x: fix UAF in SDIO TX path when out of memory
+# mt76: fix memory leak in USB TX path
+#   Eason Lai's pair, carried 2026-09-08 for issue 83. On the list since
+#   2026-08-05, at v4 since 2026-08-27.
+#   https://lore.kernel.org/linux-wireless/20260827083526.1621600-2-eason.lai@mediatek.com/
+#   https://lore.kernel.org/linux-wireless/20260827083526.1621600-3-eason.lai@mediatek.com/

--- a/tx.c
+++ b/tx.c
@@ -813,7 +813,7 @@ int mt76_skb_adjust_pad(struct sk_buff *skb, int pad)
 		}
 	}
 
-	if (skb_pad(last, pad))
+	if (__skb_pad(last, pad, false))
 		return -ENOMEM;
 
 	__skb_put(last, pad);

--- a/usb.c
+++ b/usb.c
@@ -893,6 +893,9 @@ mt76u_tx_queue_skb(struct mt76_phy *phy, struct mt76_queue *q,
 		   enum mt76_txq_id qid, struct sk_buff *skb,
 		   struct mt76_wcid *wcid, struct ieee80211_sta *sta)
 {
+	struct ieee80211_tx_status status = {
+		.sta = sta,
+	};
 	struct mt76_tx_info tx_info = {
 		.skb = skb,
 	};
@@ -900,17 +903,27 @@ mt76u_tx_queue_skb(struct mt76_phy *phy, struct mt76_queue *q,
 	u16 idx = q->head;
 	int err;
 
-	if (q->queued == q->ndesc)
-		return -ENOSPC;
+	if (q->queued == q->ndesc) {
+		err = -ENOSPC;
+		goto err_free_skb;
+	}
 
 	skb->prev = skb->next = NULL;
 	err = dev->drv->tx_prepare_skb(dev, NULL, qid, wcid, sta, &tx_info);
 	if (err < 0)
-		return err;
+		goto err_free_skb;
 
 	err = mt76u_tx_setup_buffers(dev, tx_info.skb, q->entry[idx].urb);
-	if (err < 0)
-		return err;
+	if (err < 0) {
+		/*
+		 * mt76_tx_status_skb_get() walks the idr and dereferences
+		 * a freed skb. This SKB is not counted in non-AQL counter
+		 * due to error return, so using 0xffff as wcid to keep
+		 * balanced.
+		 */
+		mt76_tx_complete_skb(dev, 0xffff, tx_info.skb);
+		goto err_ret;
+	}
 
 	mt76u_fill_bulk_urb(dev, USB_DIR_OUT, q->ep, q->entry[idx].urb,
 			    mt76u_complete_tx, &q->entry[idx]);
@@ -921,6 +934,14 @@ mt76u_tx_queue_skb(struct mt76_phy *phy, struct mt76_queue *q,
 	q->queued++;
 
 	return idx;
+
+err_free_skb:
+	status.skb = tx_info.skb;
+	spin_lock_bh(&dev->rx_lock);
+	ieee80211_tx_status_ext(dev->hw, &status);
+	spin_unlock_bh(&dev->rx_lock);
+err_ret:
+	return err;
 }
 
 static void mt76u_tx_kick(struct mt76_dev *dev, struct mt76_queue *q)


### PR DESCRIPTION
Eason Lai's fix for issue 83, at v4 on the list. The commits are his.

A frame too short to send is refused at the USB queue and never freed, so the sending socket stays charged. Enough of those and it blocks. That is where the reporter's supplicant was stuck. The second patch frees the frame on each refusal, as the DMA path does. Without the first, the padding helper frees it twice.

Tested on an MT7921AU, Pi 5, 6.18.34:

	                       main               this branch
	0-byte frames sent     111, then blocked  3000, no block
	1-byte control         3000               3000
	iperf3 to the AP       701/699            700/699 Mbit/s, 0 retransmits

Hans Buchheim confirmed it on a Netgear mt7921u on 7.1.9.

It does not close the report. That wedge cleared with scatter-gather off, and this exit runs first. Separate work.

Rebase merge, not squash. Squashing would put my name on Eason's commits.
