### PR TITLE
skip-picks: do not take our own active monitor un-advertise

### DIFF
--- a/skip-picks.txt
+++ b/skip-picks.txt
@@ -4,6 +4,7 @@
 2dd6e4c8  # firmware: update MT7981 firmware to version 20260515
 50a0c305  # firmware: update MT7986 firmware to version 20260515
 f6cf5faf  # firmware: update MT7996 firmware to version 20260311
+9de65849  # do not advertise active monitor. Fixed here instead, so this would switch it off
 
 # Section 2. Experimental/testing patches that have been merged here but have
 # not been sent upstream yet.


### PR DESCRIPTION
show-picks offers openwrt 9de65849, and taking it would turn active monitor off on this tree.

The commit is mine, applied upstream in July. It hides the feature on a tree where an active monitor gets no channel and captures nothing. This tree fixes that in the shared mt792x path, so hiding it here would be a regression.

Measured on a Pi 5, MT7921AU over USB 3, kernel 6.18.34, channel 1. Three runs each way, thirty seconds, passive and active interleaved. Module identity confirmed by srcversion in every arm.

| build | passive | active |
|---|---|---|
| this tree | 582 / 583 / 580 | 581 / 583 / 583, channel assigned |
| this tree plus the commit | opens normally | refused, operation not supported |
| in-kernel, harness check only | 578 / 583 / 582 | 0 / 0 / 0, no channel ever assigned |

With the entry in place show-picks drops that commit and nothing else, and the skip tally goes from three to four.
