### PR TITLE
Guard NO_VIRTUAL_MONITOR where the kernel lacks it, and correct the mt7996 threshold

### DIFF
--- a/mt792x_core.c
+++ b/mt792x_core.c
@@ -757,7 +757,10 @@ int mt792x_init_wiphy(struct ieee80211_hw *hw)
 	 * MT7927 path. Verified on hardware: active monitor now gets a real
 	 * chanctx and receives beacons at the same rate as passive monitor.
 	 */
+/* compat: IEEE80211_HW_NO_VIRTUAL_MONITOR added to mac80211 in kernel 6.13 */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 13, 0)
 	ieee80211_hw_set(hw, NO_VIRTUAL_MONITOR);
+#endif
 	ieee80211_hw_set(hw, SUPPORTS_PS);
 	ieee80211_hw_set(hw, SUPPORTS_DYNAMIC_PS);
 	ieee80211_hw_set(hw, SUPPORTS_VHT_EXT_NSS_BW);

--- a/mt7996/init.c
+++ b/mt7996/init.c
@@ -539,8 +539,10 @@ mt7996_init_wiphy(struct ieee80211_hw *hw, struct mtk_wed_device *wed)
 	ieee80211_hw_set(hw, HAS_RATE_CONTROL);
 	ieee80211_hw_set(hw, SUPPORTS_TX_ENCAP_OFFLOAD);
 	ieee80211_hw_set(hw, SUPPORTS_RX_DECAP_OFFLOAD);
-	/* compat: IEEE80211_HW_NO_VIRTUAL_MONITOR added to mac80211 in kernel 6.15 */
-#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 15, 0)
+/* compat: upstream mt7996 sets this from kernel 6.14; the flag itself
+ * arrived in 6.13
+ */
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(6, 14, 0)
 	ieee80211_hw_set(hw, NO_VIRTUAL_MONITOR);
 #endif
 	ieee80211_hw_set(hw, SUPPORTS_MULTI_BSSID);


### PR DESCRIPTION
@Ashcal9669 two guards for the same flag, one on your mt792x line and one on a wrong threshold of mine. Does this look right?

#105 first. `NO_VIRTUAL_MONITOR` is set unconditionally in mt792x, and it arrived in 6.13, so the tree does not build on anything older. The reporter is on Debian 13 with 6.12.107, and mainline does not bind MT7902 until 7.1, so this repo is their only driver.

The second is mine: mt7996 guards at 6.15, so 6.14 lost the flag here.

```
flag added to mac80211      6.13   9d40f7e32774
upstream mt7996 adopts it   6.14   69d54ce7491d
```

Built:

```
kernel                 errors  warns  undefined  modules  loaded
Debian 13, 6.12.101         0      0          0       26   26/26
Fedora, 7.2.3               0      0          0       26     n/a
```

Across every release only two cells change: mt792x on 6.12 builds, mt7996 on 6.14 gains the flag.

Not marked Closes: Secure Boot is on for the reporter, so the module still needs signing and enrolling first.
